### PR TITLE
context based dynamic serialization

### DIFF
--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -173,7 +173,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         self.api = APIContainer(self)
         self.endpoints = APIEndpointContainter(self)
         self._platform_version: str = ""
-        self._api_version: Version
+        self._api_version: Version = NullVersion  # type: ignore
         self._state: ManagerSessionState = ManagerSessionState.OPERATIVE
         self.restart_timeout: int = 1200
         self.polling_requests_timeout: int = 10

--- a/catalystwan/tests/test_endpoints.py
+++ b/catalystwan/tests/test_endpoints.py
@@ -13,7 +13,7 @@ from uuid import UUID, uuid4
 import pytest  # type: ignore
 from packaging.version import Version  # type: ignore
 from parameterized import parameterized  # type: ignore
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from typing_extensions import Annotated
 
 from catalystwan.endpoints import (
@@ -29,6 +29,7 @@ from catalystwan.endpoints import (
 from catalystwan.endpoints import logger as endpoints_logger
 from catalystwan.endpoints import post, put, request, versions, view
 from catalystwan.exceptions import APIEndpointError, APIRequestPayloadTypeError, APIVersionError, APIViewError
+from catalystwan.models.common import VersionedField
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.session_type import ProviderAsTenantView, ProviderView, TenantView
 
@@ -874,3 +875,36 @@ class TestAPIEndpoints(unittest.TestCase):
             @request("POST", "/v1/data")
             def create(self, payload: AnyBaseModel) -> None:  # type: ignore [empty-body]
                 ...
+
+    @parameterized.expand(
+        [
+            ("1.3", '{"name":"John"}'),
+            ("1.9", '{"newName":"John"}'),
+        ]
+    )
+    def test_api_version_passed_in_dump_context(self, version, expected_payload_json):
+        # Arrange
+        class Payload(BaseModel):
+            model_config = ConfigDict(populate_by_name=True)
+            name: Annotated[str, VersionedField(versions=">1.6", serialization_alias="newName")]
+
+            @model_serializer(mode="wrap")
+            def serialize(self, handler, info):
+                return VersionedField.update_model_fields(self.model_fields, handler(self), info)
+
+        class ExampleAPI(APIEndpoints):
+            @request("POST", "/v1/data")
+            def create(self, payload: Payload) -> None:  # type: ignore [empty-body]
+                ...
+
+        self.session_mock.api_version = Version(version)
+        api = ExampleAPI(self.session_mock)
+        # Act
+        api.create(Payload(name="John"))
+        # Assert
+        self.session_mock.request.assert_called_once_with(
+            "POST",
+            self.base_path + "/v1/data",
+            data=expected_payload_json,
+            headers={"content-type": "application/json"},
+        )

--- a/catalystwan/tests/test_models_common.py
+++ b/catalystwan/tests/test_models_common.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+
+import unittest
+from typing import Any, Dict, Set
+
+from packaging.version import Version  # type: ignore
+from parameterized import parameterized  # type: ignore
+from pydantic import BaseModel, ConfigDict, Field, SerializationInfo, SerializerFunctionWrapHandler, model_serializer
+from typing_extensions import Annotated
+
+from catalystwan.models.common import VersionedField
+
+A = Annotated[
+    int, VersionedField(versions=">=1", serialization_alias="a-kebab"), Field(default=0, serialization_alias="aCamel")
+]
+
+B = Annotated[
+    float,
+    VersionedField(versions=">=2", serialization_alias="b-kebab"),
+]
+
+
+class VersionedFieldsModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    a: A
+    b: B = Field(default=0.0, serialization_alias="bCamel")
+    c: Annotated[bool, VersionedField(versions=">=3", serialization_alias="c-kebab")] = False
+
+    @model_serializer(mode="wrap")
+    def dump(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Dict[str, Any]:
+        return VersionedField.update_model_fields(self.model_fields, handler(self), info)
+
+
+class Payload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    data: VersionedFieldsModel
+
+
+class TestModelsCommonVersionedField(unittest.TestCase):
+    def setUp(self):
+        self.model = Payload(data=VersionedFieldsModel())
+
+    @parameterized.expand(
+        [
+            ("0.9", {"aCamel", "bCamel", "c"}),
+            ("1.0", {"a-kebab", "bCamel", "c"}),
+            ("2.1", {"a-kebab", "b-kebab", "c"}),
+            ("3.0.1", {"a-kebab", "b-kebab", "c-kebab"}),
+        ]
+    )
+    def test_versioned_field_model_serialize(self, version: str, expected_fields: Set[str]):
+        data_dict = self.model.model_dump(by_alias=True, context={"api_version": Version(version)}).get("data")
+        assert expected_fields == data_dict.keys()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ flake8-quotes = "^3.3.1"
 clint = "^0.5.1"
 requests-toolbelt = "^1.0.0"
 packaging = "^23.0"
-pydantic = "^2.5"
+pydantic = "^2.7"
 typing-extensions = "^4.6.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Pull Request summary:
It is now possible to have different serialization alias to be chosen dynamically based on running Manager api version.
This extends the possibility to reuse single payload model definition for different Manager API versions.

We are utilizing a new feature introduced in pydantic 2.7.0 [Ability to pass a context object to the serialization methods](https://github.com/pydantic/pydantic/issues/7143).
Context dict containing `api_version` key is provided before sending payload automatically when using methods decorated with `@post`, `@put` etc.
When model fields are annotated with `VersionedField` - model_serializer updates fields using helper when `api_version` is given in context.

- introduce `VersionedField` annotation
- introduce `update_model_fields()` helper
- automatically inject context containing `api_version` when dumping model before payload is sent

# Full usage example:
```python
from catalystwan.models.common import VersionedField
from pydantic import BaseModel, model_serializer
from typing_extensions import Annotated
from catalystwan.endpoints import APIEndpoints, post
from catalystwan.session import create_manager_session


# 1. provide annotation with matching version specifier and desired serialization_alias
class TestPayload(BaseModel):
    data: Annotated[
        bool,
        VersionedField(versions=">=20.13,<20.15", serialization_alias="dataForApiBefore-20.15"),
        VersionedField(versions=">=20.15", serialization_alias="dataForApiAfter-20.15"),
    ] = True

    # 2. provide model_serializer which utilize helper
    @model_serializer(mode="wrap")
    def serialize(self, handler, serialization_info):
        return VersionedField.update_model_fields(self.model_fields, handler(self), serialization_info)


class CustomAPI(APIEndpoints):

    @post("/test")
    def test_create(payload: TestPayload) -> None:
        ...


with create_manager_session(**login) as session:
    api = CustomAPI(session)
    api.test_create(payload=TestPayload()) # serialization alias is determined in runtime according to matching api version
```

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
