### PR TITLE
allow centralized cli policy creation

### DIFF
--- a/catalystwan/models/policy/policy.py
+++ b/catalystwan/models/policy/policy.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 
 import datetime
-from typing import List, Literal, Optional, Sequence
+from typing import List, Literal, Optional, Sequence, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -70,8 +70,9 @@ class PolicyCreationPayload(BaseModel):
         default="default description", serialization_alias="policyDescription", validation_alias="policyDescription"
     )
     policy_type: str = Field(serialization_alias="policyType", validation_alias="policyType")
-    policy_definition: PolicyDefinition = Field(
-        serialization_alias="policyDefinition", validation_alias="policyDefinition"
+    policy_definition: Union[PolicyDefinition, str] = Field(
+        serialization_alias="policyDefinition",
+        validation_alias="policyDefinition",
     )
     is_policy_activated: bool = Field(
         default=False, serialization_alias="isPolicyActivated", validation_alias="isPolicyActivated"


### PR DESCRIPTION
# Pull Request summary:
It now possible to create CLI based centralized policy

# Example:
```python
from catalystwan.models.policy import CentralizedPolicy 
from catalystwan.session import create_manager_session

with create_manager_session(...) as session:
    cli_config_string = "<...>"
    cli = CentralizedPolicy(policy_name="my-policy-cli", policy_type="cli", policy_definition=cli_config_string)
    session.api.policy.centralized.create(cli)
```

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
