### PR TITLE
Adding api support for Lxc virutal image Upgrade,Activate and Delete …

### DIFF
--- a/catalystwan/api/api_container.py
+++ b/catalystwan/api/api_container.py
@@ -26,6 +26,7 @@ from catalystwan.api.partition_manager_api import PartitionManagerAPI
 from catalystwan.api.policy_api import PolicyAPI
 from catalystwan.api.resource_pool_api import ResourcePoolAPI
 from catalystwan.api.software_action_api import SoftwareActionAPI
+from catalystwan.api.virtual_image_action_api import LxcActionAPI
 from catalystwan.api.speedtest_api import SpeedtestAPI
 from catalystwan.api.template_api import TemplatesAPI
 from catalystwan.api.tenant_backup_restore_api import TenantBackupRestoreAPI
@@ -58,6 +59,7 @@ class APIContainer:
         self.repository = RepositoryAPI(session)
         self.resource_pool = ResourcePoolAPI(session)
         self.software = SoftwareActionAPI(session)
+        self.lxcsoftware = LxcActionAPI(session)
         self.partition = PartitionManagerAPI(session)
         self.users = UsersAPI(session)
         self.cluster_management = ClusterManagementAPI(session)

--- a/catalystwan/api/api_container.py
+++ b/catalystwan/api/api_container.py
@@ -26,13 +26,13 @@ from catalystwan.api.partition_manager_api import PartitionManagerAPI
 from catalystwan.api.policy_api import PolicyAPI
 from catalystwan.api.resource_pool_api import ResourcePoolAPI
 from catalystwan.api.software_action_api import SoftwareActionAPI
-from catalystwan.api.virtual_image_action_api import LxcActionAPI
 from catalystwan.api.speedtest_api import SpeedtestAPI
 from catalystwan.api.template_api import TemplatesAPI
 from catalystwan.api.tenant_backup_restore_api import TenantBackupRestoreAPI
 from catalystwan.api.tenant_management_api import TenantManagementAPI
 from catalystwan.api.tenant_migration_api import TenantMigrationAPI
 from catalystwan.api.versions_utils import RepositoryAPI
+from catalystwan.api.virtual_image_action_api import LxcActionAPI
 
 if TYPE_CHECKING:
     from catalystwan.session import ManagerSession

--- a/catalystwan/api/versions_utils.py
+++ b/catalystwan/api/versions_utils.py
@@ -10,10 +10,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from catalystwan.endpoints.configuration.software_actions import SoftwareImageDetails
 from catalystwan.endpoints.configuration_device_actions import (
-    PartitionDevice,
-    LxcActivateDevice,
     InstallLxcImage,
+    LxcActivateDevice,
     LxcUpgradeDevice,
+    PartitionDevice,
 )
 from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.exceptions import ImageNotInRepositoryError

--- a/catalystwan/api/versions_utils.py
+++ b/catalystwan/api/versions_utils.py
@@ -9,8 +9,12 @@ from typing import TYPE_CHECKING, Dict, List, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 from catalystwan.endpoints.configuration.software_actions import SoftwareImageDetails
-from catalystwan.endpoints.configuration_device_actions import PartitionDevice, LxcActivateDevice,InstallLxcImage,\
-    LxcUpgradeDevice
+from catalystwan.endpoints.configuration_device_actions import (
+    PartitionDevice,
+    LxcActivateDevice,
+    InstallLxcImage,
+    LxcUpgradeDevice,
+)
 from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.exceptions import ImageNotInRepositoryError
 from catalystwan.typed_list import DataSequence
@@ -75,7 +79,9 @@ class RepositoryAPI:
         Returns:
             list: software images list
         """
-        software_images = self.session.endpoints.configuration_software_actions.get_list_of_all_images("imageType=virtualmachine")
+        software_images = self.session.endpoints.configuration_software_actions.get_list_of_all_images(
+            "imageType=virtualmachine"
+        )
         return software_images
 
     def get_devices_versions_repository(self) -> Dict[str, DeviceSoftwareRepository]:
@@ -220,33 +226,49 @@ class DeviceVersions:
                     f"device.device_ip (current value: {device.device_ip})"
                 )
 
-    def get_lxcactivate_device_list(self, version_to_set_up: str, devices: DataSequence[DeviceDetailsResponse],
-                        ) -> DataSequence[PartitionDevice]:
+    def get_lxcactivate_device_list(
+        self,
+        version_to_set_up: str,
+        devices: DataSequence[DeviceDetailsResponse],
+    ) -> DataSequence[PartitionDevice]:
         self._validate_devices_required_fields(devices)
         install_image_payload = DataSequence(
             InstallLxcImage,
-            [InstallLxcImage(network_function_type="app-hosting", version_name=version_to_set_up,
-                             version_type_name="UTD-Snort-Feature")]
+            [
+                InstallLxcImage(
+                    network_function_type="app-hosting",
+                    version_name=version_to_set_up,
+                    version_type_name="UTD-Snort-Feature",
+                )
+            ],
         )
         devices_payload = DataSequence(
             LxcActivateDevice,
-            [LxcActivateDevice(device_id=device.uuid, device_ip=device.local_system_ip,
-                               install_images=install_image_payload) for device in devices],  # type: ignore
+            [
+                LxcActivateDevice(
+                    device_id=device.uuid, device_ip=device.local_system_ip, install_images=install_image_payload
+                )
+                for device in devices
+            ],  # type: ignore
         )
 
         return devices_payload
 
-    def get_lxcupgrade_device_list(self, version_to_set_up: str, devices: DataSequence[DeviceDetailsResponse],
-                        ) -> DataSequence[PartitionDevice]:
+    def get_lxcupgrade_device_list(
+        self,
+        version_to_set_up: str,
+        devices: DataSequence[DeviceDetailsResponse],
+    ) -> DataSequence[PartitionDevice]:
         self._validate_devices_required_fields(devices)
-        install_image_payload = DataSequence(
-            InstallLxcImage,
-            [InstallLxcImage(version_name=version_to_set_up)]
-        )
+        install_image_payload = DataSequence(InstallLxcImage, [InstallLxcImage(version_name=version_to_set_up)])
         devices_payload = DataSequence(
             LxcUpgradeDevice,
-            [LxcUpgradeDevice(device_id=device.uuid, device_ip=device.local_system_ip,
-                               install_images=install_image_payload) for device in devices],  # type: ignore
+            [
+                LxcUpgradeDevice(
+                    device_id=device.uuid, device_ip=device.local_system_ip, install_images=install_image_payload
+                )
+                for device in devices
+            ],  # type: ignore
         )
 
         return devices_payload
@@ -269,7 +291,8 @@ class DeviceVersions:
         self._validate_devices_required_fields(devices)
         devices_payload = DataSequence(
             PartitionDevice,
-            [PartitionDevice(device_id=device.uuid, device_ip=device.local_system_ip) for device in devices],  # type: ignore
+            [PartitionDevice(device_id=device.uuid, device_ip=device.local_system_ip) for device in devices],
+            # type: ignore
         )
 
         all_dev_versions = self.repository.get_devices_versions_repository()
@@ -338,9 +361,10 @@ class DeviceVersions:
 
         devices_payload = DataSequence(
             PartitionDevice,
-            [PartitionDevice(
-                device_id=device.uuid, device_ip=device.local_system_ip  # type: ignore
-            ) for device in devices],  # type: ignore
+            [
+                PartitionDevice(device_id=device.uuid, device_ip=device.local_system_ip)  # type: ignore
+                for device in devices
+            ],  # type: ignore
         )
         all_dev_versions = self.repository.get_devices_versions_repository()
         for device in devices_payload:

--- a/catalystwan/api/versions_utils.py
+++ b/catalystwan/api/versions_utils.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Dict, List, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 from catalystwan.endpoints.configuration.software_actions import SoftwareImageDetails
-from catalystwan.endpoints.configuration_device_actions import PartitionDevice
+from catalystwan.endpoints.configuration_device_actions import PartitionDevice, LxcActivateDevice,InstallLxcImage,\
+    LxcUpgradeDevice
 from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.exceptions import ImageNotInRepositoryError
 from catalystwan.typed_list import DataSequence
@@ -65,6 +66,16 @@ class RepositoryAPI:
             list: software images list
         """
         software_images = self.session.endpoints.configuration_software_actions.get_list_of_all_images()
+        return software_images
+
+    def get_all_virtual_images(self) -> DataSequence[SoftwareImageDetails]:
+        """
+        Get all info about all software images stored in Vmanage repository
+
+        Returns:
+            list: software images list
+        """
+        software_images = self.session.endpoints.configuration_software_actions.get_list_of_all_images("imageType=virtualmachine")
         return software_images
 
     def get_devices_versions_repository(self) -> Dict[str, DeviceSoftwareRepository]:
@@ -209,6 +220,37 @@ class DeviceVersions:
                     f"device.device_ip (current value: {device.device_ip})"
                 )
 
+    def get_lxcactivate_device_list(self, version_to_set_up: str, devices: DataSequence[DeviceDetailsResponse],
+                        ) -> DataSequence[PartitionDevice]:
+        self._validate_devices_required_fields(devices)
+        install_image_payload = DataSequence(
+            InstallLxcImage,
+            [InstallLxcImage(network_function_type="app-hosting", version_name=version_to_set_up,
+                             version_type_name="UTD-Snort-Feature")]
+        )
+        devices_payload = DataSequence(
+            LxcActivateDevice,
+            [LxcActivateDevice(device_id=device.uuid, device_ip=device.local_system_ip,
+                               install_images=install_image_payload) for device in devices],  # type: ignore
+        )
+
+        return devices_payload
+
+    def get_lxcupgrade_device_list(self, version_to_set_up: str, devices: DataSequence[DeviceDetailsResponse],
+                        ) -> DataSequence[PartitionDevice]:
+        self._validate_devices_required_fields(devices)
+        install_image_payload = DataSequence(
+            InstallLxcImage,
+            [InstallLxcImage(version_name=version_to_set_up)]
+        )
+        devices_payload = DataSequence(
+            LxcUpgradeDevice,
+            [LxcUpgradeDevice(device_id=device.uuid, device_ip=device.local_system_ip,
+                               install_images=install_image_payload) for device in devices],  # type: ignore
+        )
+
+        return devices_payload
+
     def _get_device_list_in(
         self, version_to_set_up: str, devices: DataSequence[DeviceDetailsResponse], version_type: str
     ) -> DataSequence[PartitionDevice]:
@@ -227,8 +269,9 @@ class DeviceVersions:
         self._validate_devices_required_fields(devices)
         devices_payload = DataSequence(
             PartitionDevice,
-            [PartitionDevice(device_id=device.uuid, device_ip=device.device_ip) for device in devices],  # type: ignore
+            [PartitionDevice(device_id=device.uuid, device_ip=device.local_system_ip) for device in devices],  # type: ignore
         )
+
         all_dev_versions = self.repository.get_devices_versions_repository()
         for device in devices_payload:
             device_versions = getattr(all_dev_versions[device.device_id], version_type)

--- a/catalystwan/api/versions_utils.py
+++ b/catalystwan/api/versions_utils.py
@@ -230,23 +230,22 @@ class DeviceVersions:
         self,
         version_to_set_up: str,
         devices: DataSequence[DeviceDetailsResponse],
-    ) -> DataSequence[PartitionDevice]:
+    ) -> DataSequence[LxcActivateDevice]:
         self._validate_devices_required_fields(devices)
-        install_image_payload = DataSequence(
-            InstallLxcImage,
-            [
-                InstallLxcImage(
-                    network_function_type="app-hosting",
-                    version_name=version_to_set_up,
-                    version_type_name="UTD-Snort-Feature",
-                )
-            ],
-        )
+        install_image_payload = [
+            InstallLxcImage(
+                network_function_type="app-hosting",
+                version_name=version_to_set_up,
+                version_type_name="UTD-Snort-Feature",
+            )
+        ]
         devices_payload = DataSequence(
             LxcActivateDevice,
             [
                 LxcActivateDevice(
-                    device_id=device.uuid, device_ip=device.local_system_ip, install_images=install_image_payload
+                    device_id=str(device.uuid),
+                    device_ip=str(device.local_system_ip),
+                    install_images=install_image_payload,
                 )
                 for device in devices
             ],  # type: ignore
@@ -258,14 +257,16 @@ class DeviceVersions:
         self,
         version_to_set_up: str,
         devices: DataSequence[DeviceDetailsResponse],
-    ) -> DataSequence[PartitionDevice]:
+    ) -> DataSequence[LxcUpgradeDevice]:
         self._validate_devices_required_fields(devices)
-        install_image_payload = DataSequence(InstallLxcImage, [InstallLxcImage(version_name=version_to_set_up)])
+        install_image_payload = [InstallLxcImage(version_name=version_to_set_up)]
         devices_payload = DataSequence(
             LxcUpgradeDevice,
             [
                 LxcUpgradeDevice(
-                    device_id=device.uuid, device_ip=device.local_system_ip, install_images=install_image_payload
+                    device_id=str(device.uuid),
+                    device_ip=str(device.local_system_ip),
+                    install_images=install_image_payload,
                 )
                 for device in devices
             ],  # type: ignore
@@ -291,7 +292,7 @@ class DeviceVersions:
         self._validate_devices_required_fields(devices)
         devices_payload = DataSequence(
             PartitionDevice,
-            [PartitionDevice(device_id=device.uuid, device_ip=device.local_system_ip) for device in devices],
+            [PartitionDevice(device_id=str(device.uuid), device_ip=str(device.local_system_ip)) for device in devices],
             # type: ignore
         )
 

--- a/catalystwan/api/virtual_image_action_api.py
+++ b/catalystwan/api/virtual_image_action_api.py
@@ -9,9 +9,9 @@ from catalystwan.api.task_status_api import Task
 from catalystwan.api.versions_utils import DeviceVersions, RepositoryAPI
 from catalystwan.endpoints.configuration_device_actions import (
     LxcImageActivatePayload,
+    LxcImageDeletePayload,
     LxcImageUpgradePayload,
     LxcInstallInput,
-    LxcImageDeletePayload,
 )
 from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.exceptions import EmptyVersionPayloadError, ImageNotInRepositoryError  # type: ignore

--- a/catalystwan/api/virtual_image_action_api.py
+++ b/catalystwan/api/virtual_image_action_api.py
@@ -56,7 +56,7 @@ class LxcActionAPI:
     def lxcactivate(
         self,
         devices: DataSequence[DeviceDetailsResponse],
-        version_to_activate: [str],
+        version_to_activate: str,
     ) -> Task:
         """
         Requires that selected devices have already version_to_activate installed(upgraded)
@@ -156,7 +156,7 @@ class LxcActionAPI:
     def lxcdelete(
         self,
         devices: DataSequence[DeviceDetailsResponse],
-        version_to_delete: [str],
+        version_to_delete: str,
     ) -> Task:
         """
         Requires that selected devices have already version_to_delete

--- a/catalystwan/api/virtual_image_action_api.py
+++ b/catalystwan/api/virtual_image_action_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from catalystwan.api.task_status_api import Task
 from catalystwan.api.versions_utils import DeviceVersions, RepositoryAPI
@@ -11,7 +11,7 @@ from catalystwan.endpoints.configuration_device_actions import (
     LxcImageActivatePayload,
     LxcImageUpgradePayload,
     LxcInstallInput,
-    LxcImageDeletePayload
+    LxcImageDeletePayload,
 )
 from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
 from catalystwan.exceptions import EmptyVersionPayloadError, ImageNotInRepositoryError  # type: ignore
@@ -87,10 +87,12 @@ class LxcActionAPI:
                 raise EmptyVersionPayloadError("lxc activate payload contains entry with empty version field.")
 
         device_type = get_install_specification(devices.first()).device_type.value
-        install_input = LxcInstallInput(v_edge_vpn="0",version_type="vmanage")
+        install_input = LxcInstallInput(v_edge_vpn="0", version_type="vmanage")
         partition_payload = LxcImageActivatePayload(
-            action="lxc_activate", devices=[dev for dev in payload_devices], device_type=device_type,
-            input=install_input
+            action="lxc_activate",
+            devices=[dev for dev in payload_devices],
+            device_type=device_type,
+            input=install_input,
         )
 
         partition_action = self.session.endpoints.configuration_device_actions.process_lxc_activate(
@@ -140,10 +142,9 @@ class LxcActionAPI:
                 raise EmptyVersionPayloadError("lxc upgrade payload contains entry with empty version field.")
 
         device_type = get_install_specification(devices.first()).device_type.value
-        install_input = LxcInstallInput(v_edge_vpn="0",version_type="vmanage")
+        install_input = LxcInstallInput(v_edge_vpn="0", version_type="vmanage")
         partition_payload = LxcImageUpgradePayload(
-            action="lxc_upgrade", devices=[dev for dev in payload_devices], device_type=device_type,
-            input=install_input
+            action="lxc_upgrade", devices=[dev for dev in payload_devices], device_type=device_type, input=install_input
         )
 
         partition_action = self.session.endpoints.configuration_device_actions.process_lxc_upgrade(
@@ -187,7 +188,9 @@ class LxcActionAPI:
 
         device_type = get_install_specification(devices.first()).device_type.value
         partition_payload = LxcImageDeletePayload(
-            action="lxc_delete", devices=[dev for dev in payload_devices], device_type=device_type,
+            action="lxc_delete",
+            devices=[dev for dev in payload_devices],
+            device_type=device_type,
         )
 
         partition_action = self.session.endpoints.configuration_device_actions.process_lxc_delete(

--- a/catalystwan/api/virtual_image_action_api.py
+++ b/catalystwan/api/virtual_image_action_api.py
@@ -1,0 +1,197 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List, Optional, cast
+
+from catalystwan.api.task_status_api import Task
+from catalystwan.api.versions_utils import DeviceVersions, RepositoryAPI
+from catalystwan.endpoints.configuration_device_actions import (
+    LxcImageActivatePayload,
+    LxcImageUpgradePayload,
+    LxcInstallInput,
+    LxcImageDeletePayload
+)
+from catalystwan.endpoints.configuration_device_inventory import DeviceDetailsResponse
+from catalystwan.exceptions import EmptyVersionPayloadError, ImageNotInRepositoryError  # type: ignore
+from catalystwan.typed_list import DataSequence
+from catalystwan.utils.upgrades_helper import get_install_specification, validate_personality_homogeneity
+
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from catalystwan.session import ManagerSession
+
+
+class LxcActionAPI:
+    """
+    API methods for virtual software actions. All methods
+    are executable on all device categories.
+
+    Usage example:
+    # Create session
+    session = create_manager_session(...)
+
+    # Prepare specific device for Lxc image actions
+    all_dev = session.api.devices.get()
+    dev = all_dev.filter(hostname="pm1044")
+    ver = "1.0.0_SV3.1.67.0_XE17.14"
+
+    # Upgrade
+    del_id = session.api.lxcsoftware.lxcdelete(dev,ver)
+    up_id = session.api.lxcsoftware.lxcupgrade(dev,ver)
+    act_id = session.api.lxcsoftware.lxcactivate(dev,ver)
+
+    # Check upgrade status
+    TaskAPI(session, software_action_id).wait_for_completed()
+    """
+
+    def __init__(self, session: ManagerSession) -> None:
+        self.session = session
+        self.repository = RepositoryAPI(self.session)
+        self.device_versions = DeviceVersions(self.session)
+
+    def lxcactivate(
+        self,
+        devices: DataSequence[DeviceDetailsResponse],
+        version_to_activate: [str],
+    ) -> Task:
+        """
+        Requires that selected devices have already version_to_activate installed(upgraded)
+
+        Args:
+            devices (List[DeviceDetailsResponse]): For those devices software will be activated
+            version_to_activate (Optional[str]): version to be set as current version
+
+            Notice: Have to pass one of those arguments (version_to_activate, image)
+
+        Raises:
+            EmptyVersionPayloadError: If selected version_to_activate or image not detected in available files
+
+        Returns:
+            str: Activate software action id
+        """
+        validate_personality_homogeneity(devices)
+        version = cast(str, version_to_activate)
+
+        if not version:
+            raise ImageNotInRepositoryError(
+                "Based on provided arguments, virtual software version to activate on device(s) cannot be detected."
+            )
+
+        payload_devices = self.device_versions.get_lxcactivate_device_list(version, devices)
+        for device in payload_devices:
+            if not device.install_images[0].version_name:
+                raise EmptyVersionPayloadError("lxc activate payload contains entry with empty version field.")
+
+        device_type = get_install_specification(devices.first()).device_type.value
+        install_input = LxcInstallInput(v_edge_vpn="0",version_type="vmanage")
+        partition_payload = LxcImageActivatePayload(
+            action="lxc_activate", devices=[dev for dev in payload_devices], device_type=device_type,
+            input=install_input
+        )
+
+        partition_action = self.session.endpoints.configuration_device_actions.process_lxc_activate(
+            payload=partition_payload
+        )
+
+        return Task(self.session, partition_action.id)
+
+    def lxcupgrade(
+        self,
+        devices: DataSequence[DeviceDetailsResponse],
+        version_to_upgrade: Optional[str] = "",
+        image: Optional[str] = "",
+    ) -> Task:
+        """
+        Requires that selected devices have already version_to_upgrade
+
+        Args:
+            devices (List[DeviceDetailsResponse]): For those devices software will be activated
+            version_to_upgrade (Optional[str]): version to be set as current version
+            image (Optional[str]): software image name in available files
+
+            Notice: Have to pass one of those arguments (version_to_activate, image)
+
+        Raises:
+            EmptyVersionPayloadError: If selected version_to_activate or image not detected in available files
+
+        Returns:
+            str: Activate software action id
+        """
+        validate_personality_homogeneity(devices)
+        if image and not version_to_upgrade:
+            version = cast(str, self.repository.get_image_version(image))
+        elif version_to_upgrade and not image:
+            version = cast(str, version_to_upgrade)
+        else:
+            raise ValueError("You can not provide software_image and image version at the same time!")
+
+        if not version:
+            raise ImageNotInRepositoryError(
+                "Based on provided arguments, virtual software version to activate on device(s) cannot be detected."
+            )
+
+        payload_devices = self.device_versions.get_lxcupgrade_device_list(version, devices)
+        for device in payload_devices:
+            if not device.install_images[0].version_name:
+                raise EmptyVersionPayloadError("lxc upgrade payload contains entry with empty version field.")
+
+        device_type = get_install_specification(devices.first()).device_type.value
+        install_input = LxcInstallInput(v_edge_vpn="0",version_type="vmanage")
+        partition_payload = LxcImageUpgradePayload(
+            action="lxc_upgrade", devices=[dev for dev in payload_devices], device_type=device_type,
+            input=install_input
+        )
+
+        partition_action = self.session.endpoints.configuration_device_actions.process_lxc_upgrade(
+            payload=partition_payload
+        )
+
+        return Task(self.session, partition_action.id)
+
+    def lxcdelete(
+        self,
+        devices: DataSequence[DeviceDetailsResponse],
+        version_to_delete: [str],
+    ) -> Task:
+        """
+        Requires that selected devices have already version_to_delete
+
+        Args:
+            devices (List[DeviceDetailsResponse]): For those devices lxc software will be deleted
+            version_to_delete (Optional[str]): version to delete
+
+            Notice: Have to pass one of those arguments (version_to_delete)
+
+        Raises:
+            EmptyVersionPayloadError: If selected version_to_activate or image not detected in available files
+
+        Returns:
+            str: Delete software action id
+        """
+        validate_personality_homogeneity(devices)
+        version = cast(str, version_to_delete)
+
+        if not version:
+            raise ImageNotInRepositoryError(
+                "Based on provided arguments, virtual software version to delete on device(s) cannot be detected."
+            )
+
+        payload_devices = self.device_versions.get_lxcupgrade_device_list(version, devices)
+        for device in payload_devices:
+            if not device.install_images[0].version_name:
+                raise EmptyVersionPayloadError("lxc device payload contains entry with empty version field.")
+
+        device_type = get_install_specification(devices.first()).device_type.value
+        partition_payload = LxcImageDeletePayload(
+            action="lxc_delete", devices=[dev for dev in payload_devices], device_type=device_type,
+        )
+
+        partition_action = self.session.endpoints.configuration_device_actions.process_lxc_delete(
+            payload=partition_payload
+        )
+
+        return Task(self.session, partition_action.id)

--- a/catalystwan/endpoints/configuration_device_actions.py
+++ b/catalystwan/endpoints/configuration_device_actions.py
@@ -100,7 +100,7 @@ class PartitionActionPayload(BaseModel):
 class LxcInstallInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    v_edge_vpn: int = Field(serialization_alias="vEdgeVPN", validation_alias="vEdgeVPN")
+    v_edge_vpn: str = Field(serialization_alias="vEdgeVPN", validation_alias="vEdgeVPN")
     version_type: VersionType = Field(serialization_alias="versionType", validation_alias="versionType")
 
 
@@ -246,7 +246,8 @@ class ConfigurationDeviceActions(APIEndpoints):
     @get("/device/action/install/devices/{device_type}", "data")
     def get_list_of_installed_devices(
         self, device_type: DeviceType = "controller", params: GroupId = GroupId()
-    ) -> DataSequence[InstalledDeviceData]: ...
+    ) -> DataSequence[InstalledDeviceData]:
+        ...
 
     def generate_install_info(self):
         # GET /device/action/install
@@ -277,7 +278,8 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @get("/device/action/ztp/upgrade/setting", "data")
-    def get_ztp_upgrade_config_setting(self) -> DataSequence[ZTPUpgradeSettings]: ...
+    def get_ztp_upgrade_config_setting(self) -> DataSequence[ZTPUpgradeSettings]:
+        ...
 
     def initiate_image_download(self):
         # POST /device/action/image-download
@@ -292,21 +294,24 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @post("/device/action/changepartition")
-    def process_mark_change_partition(self, payload: PartitionActionPayload) -> ActionId: ...
+    def process_mark_change_partition(self, payload: PartitionActionPayload) -> ActionId:
+        ...
 
     def process_deactivate_smu(self):
         # POST /device/action/deactivate
         ...
 
     @post("/device/action/defaultpartition")
-    def process_mark_default_partition(self, payload: PartitionActionPayload) -> ActionId: ...
+    def process_mark_default_partition(self, payload: PartitionActionPayload) -> ActionId:
+        ...
 
     def process_delete_amp_api_key(self):
         # DELETE /device/action/security/amp/apikey/{uuid}
         ...
 
     @post("/device/action/install")
-    def process_install_operation(self, payload: InstallActionPayload) -> ActionId: ...
+    def process_install_operation(self, payload: InstallActionPayload) -> ActionId:
+        ...
 
     @post("/device/action/lxcactivate")
     def process_lxc_activate(self, payload: PartitionActionPayload) -> ActionId:
@@ -340,7 +345,8 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @post("/device/action/removepartition")
-    def process_remove_partition(self, payload: RemovePartitionActionPayload) -> ActionId: ...
+    def process_remove_partition(self, payload: RemovePartitionActionPayload) -> ActionId:
+        ...
 
     def process_remove_software_image(self):
         # POST /device/action/image-remove

--- a/catalystwan/endpoints/configuration_device_actions.py
+++ b/catalystwan/endpoints/configuration_device_actions.py
@@ -50,12 +50,18 @@ class PartitionDevice(BaseModel):
 
 VersionList = Annotated[Union[str, List[str]], BeforeValidator(convert_to_list)]
 
+
 class InstallLxcImage(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    network_function_type: str = Field(default="app-hosting", serialization_alias="networkFunctionType", validation_alias="networkFunctionType")
+    network_function_type: str = Field(
+        default="app-hosting", serialization_alias="networkFunctionType", validation_alias="networkFunctionType"
+    )
     version_name: str = Field(serialization_alias="versionName", validation_alias="versionName")
-    version_type_name: str = Field(default="UTD-Snort-Feature", serialization_alias="versionTypeName", validation_alias="versionTypeName")
+    version_type_name: str = Field(
+        default="UTD-Snort-Feature", serialization_alias="versionTypeName", validation_alias="versionTypeName"
+    )
+
 
 class LxcActivateDevice(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -63,8 +69,9 @@ class LxcActivateDevice(BaseModel):
     device_id: str = Field(serialization_alias="deviceId", validation_alias="deviceId")
     device_ip: str = Field(serialization_alias="deviceIP", validation_alias="deviceIP")
     install_images: List[InstallLxcImage] = Field(serialization_alias="installImages", validation_alias="installImages")
-    vedge_vpn: str = Field(default="0", serialization_alias="vEdgeVPN",validation_alias="vEdgeVPN")
-    version_type: str = Field(default="vmanage",serialization_alias="versionType",validation_alias="versionType")
+    vedge_vpn: str = Field(default="0", serialization_alias="vEdgeVPN", validation_alias="vEdgeVPN")
+    version_type: str = Field(default="vmanage", serialization_alias="versionType", validation_alias="versionType")
+
 
 class LxcUpgradeDevice(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -72,6 +79,7 @@ class LxcUpgradeDevice(BaseModel):
     device_id: str = Field(serialization_alias="deviceId", validation_alias="deviceId")
     device_ip: str = Field(serialization_alias="deviceIP", validation_alias="deviceIP")
     install_images: List[InstallLxcImage] = Field(serialization_alias="installImages", validation_alias="installImages")
+
 
 class RemovePartitionDevice(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -88,6 +96,7 @@ class PartitionActionPayload(BaseModel):
     device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
     devices: List[PartitionDevice]
 
+
 class LxcInstallInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -103,6 +112,7 @@ class LxcImageActivatePayload(BaseModel):
     devices: List[LxcActivateDevice]
     input: LxcInstallInput
 
+
 class LxcImageUpgradePayload(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -111,12 +121,14 @@ class LxcImageUpgradePayload(BaseModel):
     devices: List[LxcUpgradeDevice]
     input: LxcInstallInput
 
+
 class LxcImageDeletePayload(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     action: LxcActionType
     device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
     devices: List[LxcUpgradeDevice]
+
 
 class RemovePartitionActionPayload(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -234,8 +246,7 @@ class ConfigurationDeviceActions(APIEndpoints):
     @get("/device/action/install/devices/{device_type}", "data")
     def get_list_of_installed_devices(
         self, device_type: DeviceType = "controller", params: GroupId = GroupId()
-    ) -> DataSequence[InstalledDeviceData]:
-        ...
+    ) -> DataSequence[InstalledDeviceData]: ...
 
     def generate_install_info(self):
         # GET /device/action/install
@@ -266,8 +277,7 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @get("/device/action/ztp/upgrade/setting", "data")
-    def get_ztp_upgrade_config_setting(self) -> DataSequence[ZTPUpgradeSettings]:
-        ...
+    def get_ztp_upgrade_config_setting(self) -> DataSequence[ZTPUpgradeSettings]: ...
 
     def initiate_image_download(self):
         # POST /device/action/image-download
@@ -282,24 +292,21 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @post("/device/action/changepartition")
-    def process_mark_change_partition(self, payload: PartitionActionPayload) -> ActionId:
-        ...
+    def process_mark_change_partition(self, payload: PartitionActionPayload) -> ActionId: ...
 
     def process_deactivate_smu(self):
         # POST /device/action/deactivate
         ...
 
     @post("/device/action/defaultpartition")
-    def process_mark_default_partition(self, payload: PartitionActionPayload) -> ActionId:
-        ...
+    def process_mark_default_partition(self, payload: PartitionActionPayload) -> ActionId: ...
 
     def process_delete_amp_api_key(self):
         # DELETE /device/action/security/amp/apikey/{uuid}
         ...
 
     @post("/device/action/install")
-    def process_install_operation(self, payload: InstallActionPayload) -> ActionId:
-        ...
+    def process_install_operation(self, payload: InstallActionPayload) -> ActionId: ...
 
     @post("/device/action/lxcactivate")
     def process_lxc_activate(self, payload: PartitionActionPayload) -> ActionId:
@@ -333,8 +340,7 @@ class ConfigurationDeviceActions(APIEndpoints):
         ...
 
     @post("/device/action/removepartition")
-    def process_remove_partition(self, payload: RemovePartitionActionPayload) -> ActionId:
-        ...
+    def process_remove_partition(self, payload: RemovePartitionActionPayload) -> ActionId: ...
 
     def process_remove_software_image(self):
         # POST /device/action/image-remove

--- a/catalystwan/endpoints/configuration_device_actions.py
+++ b/catalystwan/endpoints/configuration_device_actions.py
@@ -20,6 +20,7 @@ DeviceType = Literal["vedge", "controller", "vmanage"]
 VersionType = Literal["vmanage", "remote"]
 
 PartitionActionType = Literal["removepartition", "defaultpartition", "changepartition"]
+LxcActionType = Literal["lxc_activate", "lxc_upgrade", "lxc_delete"]
 
 
 class ActionId(BaseModel):
@@ -49,6 +50,28 @@ class PartitionDevice(BaseModel):
 
 VersionList = Annotated[Union[str, List[str]], BeforeValidator(convert_to_list)]
 
+class InstallLxcImage(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    network_function_type: str = Field(default="app-hosting", serialization_alias="networkFunctionType", validation_alias="networkFunctionType")
+    version_name: str = Field(serialization_alias="versionName", validation_alias="versionName")
+    version_type_name: str = Field(default="UTD-Snort-Feature", serialization_alias="versionTypeName", validation_alias="versionTypeName")
+
+class LxcActivateDevice(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    device_id: str = Field(serialization_alias="deviceId", validation_alias="deviceId")
+    device_ip: str = Field(serialization_alias="deviceIP", validation_alias="deviceIP")
+    install_images: List[InstallLxcImage] = Field(serialization_alias="installImages", validation_alias="installImages")
+    vedge_vpn: str = Field(default="0", serialization_alias="vEdgeVPN",validation_alias="vEdgeVPN")
+    version_type: str = Field(default="vmanage",serialization_alias="versionType",validation_alias="versionType")
+
+class LxcUpgradeDevice(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    device_id: str = Field(serialization_alias="deviceId", validation_alias="deviceId")
+    device_ip: str = Field(serialization_alias="deviceIP", validation_alias="deviceIP")
+    install_images: List[InstallLxcImage] = Field(serialization_alias="installImages", validation_alias="installImages")
 
 class RemovePartitionDevice(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -65,6 +88,35 @@ class PartitionActionPayload(BaseModel):
     device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
     devices: List[PartitionDevice]
 
+class LxcInstallInput(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    v_edge_vpn: int = Field(serialization_alias="vEdgeVPN", validation_alias="vEdgeVPN")
+    version_type: VersionType = Field(serialization_alias="versionType", validation_alias="versionType")
+
+
+class LxcImageActivatePayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: LxcActionType
+    device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
+    devices: List[LxcActivateDevice]
+    input: LxcInstallInput
+
+class LxcImageUpgradePayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: LxcActionType
+    device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
+    devices: List[LxcUpgradeDevice]
+    input: LxcInstallInput
+
+class LxcImageDeletePayload(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: LxcActionType
+    device_type: str = Field(serialization_alias="deviceType", validation_alias="deviceType")
+    devices: List[LxcUpgradeDevice]
 
 class RemovePartitionActionPayload(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -249,11 +301,13 @@ class ConfigurationDeviceActions(APIEndpoints):
     def process_install_operation(self, payload: InstallActionPayload) -> ActionId:
         ...
 
-    def process_lxc_activate(self):
+    @post("/device/action/lxcactivate")
+    def process_lxc_activate(self, payload: PartitionActionPayload) -> ActionId:
         # POST /device/action/lxcactivate
         ...
 
-    def process_lxc_delete(self):
+    @post("/device/action/lxcdelete")
+    def process_lxc_delete(self, payload: PartitionActionPayload) -> ActionId:
         # POST /device/action/lxcdelete
         ...
 
@@ -269,7 +323,8 @@ class ConfigurationDeviceActions(APIEndpoints):
         # POST /device/action/lxcreset
         ...
 
-    def process_lxc_upgrade(self):
+    @post("/device/action/lxcupgrade")
+    def process_lxc_upgrade(self, payload: PartitionActionPayload) -> ActionId:
         # POST /device/action/lxcupgrade
         ...
 

--- a/catalystwan/tests/test_monitoring_security_policy.py
+++ b/catalystwan/tests/test_monitoring_security_policy.py
@@ -17,7 +17,7 @@ class TestMonitoringSecurityPolicy(unittest.TestCase):
             "urlf_down": ["3.3.3.3"],
             "urlf_up": ["1.1.1.1", "2.2.2.2"],
             "zbfw_down": [],
-            "zbfw_up": ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+            "zbfw_up": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
         }
 
     @patch("catalystwan.session.ManagerSession")


### PR DESCRIPTION
…action

# Pull Request summary:
This PR contains LXC Image Action support 
1. Upgrade
2. Activate
3. Delete

Ran Black and flake8.
[Describe briefly what the PR is about]

# Description of changes:
[Add more in depth analysis of what changed, provide logs, examples of usage]

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes

Unit test:

1. Upgrade via image file name in repo
```
>>> session = create_manager_session(url="https://10.236.8.149:8443/", username="system-test", password="a1b2c3d4")
dev = session.api.devices.get()
Logged to vManage(20.15.999-3595) as system-test. The session type is SessionType.SINGLE_TENANT
>>> dev = session.api.devices.get()
>>> up_id = session.api.lxcsoftware.lxcupgrade(dev.filter(hostname="pm1044"),image = "app-hosting_UTD-Snort-Feature-aarch64_1.0.0_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240214_185836.1.0.0_SV3.1.67.0_XE17.14.aarch64.tar")
>>> 
>>> up_id
<catalystwan.api.task_status_api.Task object at 0x107d10c20>
>>> from catalystwan.api.task_status_api import Task
>>> task_up = Task(session,up_id)
>>> task_up.task_id.wait_for_completed()
TaskResult(result=True, sub_tasks_data=[SubTaskData(status='Success', status_id='success', action='lxc_upgrade', activity=['[26-Apr-2024 9:16:10 PDT] Application Upgrade action submitted for execution', '[26-Apr-2024 9:16:10 PDT] Executing device action Application Upgrade', '[26-Apr-2024 9:16:10 PDT] Total number of apps to be downloaded: 1. Apps to be downloaded are following: [app-hosting-UTD-Snort-Feature-x86_64-1.0.0_SV3.1.67.0_XE17.14]', '[26-Apr-2024 9:16:10 PDT] Started 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.0_SV3.1.67.0_XE17.14) download', '[26-Apr-2024 9:16:11 PDT]  App image: app-hosting_UTD-Snort-Feature-x86_64_1.0.0_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240214_185836.1.0.0_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 9:16:20 PDT] Connection Instance: 3, Color: biz-internet', '[26-Apr-2024 9:16:21 PDT] Device: Downloading http://172.16.240.53:8080/software/package/lxc/app-hosting_UTD-Snort-Feature-x86_64_1.0.0_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240214_185836.1.0.0_SV3.1.67.0_XE17.14.x86_64.tar?deviceId=172.10.10.44', '[26-Apr-2024 9:16:23 PDT] Device: Downloaded app image to /bootflash/.UTD_IMAGES/app-hosting_UTD-Snort-Feature-x86_64_1.0.0_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240214_185836.1.0.0_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 9:16:26 PDT] Device: Successfully downloaded app image and retrieved app version', '[26-Apr-2024 9:16:27 PDT] app-hosting-UTD-Snort-Feature-x86_64 installed', '[26-Apr-2024 9:16:27 PDT] Finished 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.0_SV3.1.67.0_XE17.14) download'], current_activity='Done - Application Upgrade', action_config='{"installImages":[{"networkFunctionType":"app-hosting","versionTypeName":"UTD-Snort-Feature","versionName":"1.0.0_SV3.1.67.0_XE17.14"}],"isDraftDisabled":false,"input":{"vEdgeVPN":"0","versionType":"vmanage"}}', order=17, uuid='C8500L-8S4X-FLX260400ZG', hostname='pm1044', site_id='600010044')])
>>> 

```
2. Upgrade api with version name and status

```
>>> up_id = session.api.lxcsoftware.lxcupgrade(dev.filter(hostname="pm1044"),"1.0.2_SV3.1.67.0_XE17.14")
>>> task_up.task_id.wait_for_completed()
Sub-tasks data for task lxc_upgrade-da708728-db4d-45a0-b30f-711f95ebaac3: 
 statuses: ['Success'], status_ids: ['success'], activities: [['[26-Apr-2024 0:07:58 PDT] Application Upgrade action submitted for execution', '[26-Apr-2024 0:07:58 PDT] Executing device action Application Upgrade', '[26-Apr-2024 0:07:59 PDT] Total number of apps to be downloaded: 1. Apps to be downloaded are following: [app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14]', '[26-Apr-2024 0:07:59 PDT] Started 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14) download', '[26-Apr-2024 0:07:59 PDT]  App image: app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 0:08:08 PDT] Connection Instance: 3, Color: biz-internet', '[26-Apr-2024 0:08:08 PDT] Device: Downloading http://172.16.240.53:8080/software/package/lxc/app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar?deviceId=172.10.10.44', '[26-Apr-2024 0:08:10 PDT] Device: Downloaded app image to /bootflash/.UTD_IMAGES/app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 0:08:14 PDT] Device: Successfully downloaded app image and retrieved app version', '[26-Apr-2024 0:08:14 PDT] app-hosting-UTD-Snort-Feature-x86_64 installed', '[26-Apr-2024 0:08:14 PDT] Finished 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14) download']].
Task polling finished, because all subtasks successfully finished.
TaskResult(result=True, sub_tasks_data=[SubTaskData(status='Success', status_id='success', action='lxc_upgrade', activity=['[26-Apr-2024 0:07:58 PDT] Application Upgrade action submitted for execution', '[26-Apr-2024 0:07:58 PDT] Executing device action Application Upgrade', '[26-Apr-2024 0:07:59 PDT] Total number of apps to be downloaded: 1. Apps to be downloaded are following: [app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14]', '[26-Apr-2024 0:07:59 PDT] Started 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14) download', '[26-Apr-2024 0:07:59 PDT]  App image: app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 0:08:08 PDT] Connection Instance: 3, Color: biz-internet', '[26-Apr-2024 0:08:08 PDT] Device: Downloading http://172.16.240.53:8080/software/package/lxc/app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar?deviceId=172.10.10.44', '[26-Apr-2024 0:08:10 PDT] Device: Downloaded app image to /bootflash/.UTD_IMAGES/app-hosting_UTD-Snort-Feature-x86_64_1.0.2_SV3.1.67.0_XE17.14_secapp-utd.BLD_V1714_THROTTLE_LATEST_20240315_033249_V17_14_0_36.1.0.2_SV3.1.67.0_XE17.14.x86_64.tar', '[26-Apr-2024 0:08:14 PDT] Device: Successfully downloaded app image and retrieved app version', '[26-Apr-2024 0:08:14 PDT] app-hosting-UTD-Snort-Feature-x86_64 installed', '[26-Apr-2024 0:08:14 PDT] Finished 1/1 app (app-hosting-UTD-Snort-Feature-x86_64-1.0.2_SV3.1.67.0_XE17.14) download'], current_activity='Done - Application Upgrade', action_config='{"installImages":[{"networkFunctionType":"app-hosting","versionTypeName":"UTD-Snort-Feature","versionName":"1.0.2_SV3.1.67.0_XE17.14"}],"isDraftDisabled":false,"input":{"vEdgeVPN":"0","versionType":"vmanage"}}', order=14, uuid='C8500L-8S4X-FLX260400ZG', hostname='pm1044', site_id='600010044')])
>>> 

```
3. Activate api and status
```
>>> from catalystwan.session import create_manager_session
>>> session = create_manager_session(url="https://10.236.8.149:8443/", username="system-test", password="a1b2c3d4")
Logged to vManage(20.15.999-3595) as system-test. The session type is SessionType.SINGLE_TENANT
>>> dev = session.api.devices.get()
>>> 
>>> 
>>> act_id = session.api.lxcsoftware.lxcactivate(dev.filter(hostname="pm1044"),"1.0.0_SV3.1.67.0_XE17.14")
>>> 
>>> 
>>> act_id
<catalystwan.api.task_status_api.Task object at 0x114500050>
>>> from catalystwan.api.task_status_api import Task
>>> task_act = Task(session,act_id)
>>> task_act.task_id.wait_for_completed()
TaskResult(result=True, sub_tasks_data=[SubTaskData(status='Success', status_id='success', action='lxc_activate', activity=['[26-Apr-2024 9:22:13 PDT] Application Activate action submitted for execution', '[26-Apr-2024 9:22:13 PDT] Executing device action Application Activate', '[26-Apr-2024 9:22:13 PDT] Total number of virtual apps to be activated: 1.', '[26-Apr-2024 9:22:14 PDT] Started virtual app (app-hosting-UTD-Snort-Feature-x86_64-1.0.0_SV3.1.67.0_XE17.14) activate', '[26-Apr-2024 9:22:26 PDT] ', '[26-Apr-2024 9:22:54 PDT] Device: utd stopped successfully. Current state is STOPPED', '[26-Apr-2024 9:25:14 PDT] Device: Success, App state: RUNNING', '[26-Apr-2024 9:25:15 PDT] app-hosting-UTD-Snort-Feature-x86_64 activated', '[26-Apr-2024 9:25:15 PDT] Finished virtual app (app-hosting-UTD-Snort-Feature-x86_64-1.0.0_SV3.1.67.0_XE17.14) activate'], current_activity='Done - Application Activate', action_config='{"installImages":[{"networkFunctionType":"app-hosting","versionTypeName":"UTD-Snort-Feature","versionName":"1.0.0_SV3.1.67.0_XE17.14"}],"isDraftDisabled":false,"input":{"vEdgeVPN":"0","versionType":"vmanage"}}', order=18, uuid='C8500L-8S4X-FLX260400ZG', hostname='pm1044', site_id='600010044')])
>>> 

```
5. Delete image api and status,

```
>>> session = create_manager_session(url="https://10.236.8.149:8443/", username="system-test", password="a1b2c3d4")
Logged to vManage(20.15.999-3595) as system-test. The session type is SessionType.SINGLE_TENANT
>>> 
>>> dev = session.api.devices.get()
>>> del_id = session.api.lxcsoftware.lxcdelete(dev.filter(hostname="pm1044"),"1.0.0_SV3.1.67.0_XE17.14")
>>> task_del.task_id.wait_for_completed()
Sub-tasks data for task lxc_delete-3b271f61-f2e8-4a33-9277-f4093605c0e1: 
 statuses: ['Success'], status_ids: ['success'], activities: [['[26-Apr-2024 0:39:31 PDT] Application Delete action submitted for execution', '[26-Apr-2024 0:39:31 PDT] Executing device action Application Delete', '[26-Apr-2024 0:39:31 PDT] Delete virtual image', '[26-Apr-2024 0:39:31 PDT] Removing virtual image UTD-Snort-Feature-1.0.0_SV3.1.67.0_XE17.14', '[26-Apr-2024 0:39:35 PDT] Virtual image UTD-Snort-Feature-1.0.0_SV3.1.67.0_XE17.14 removed']].
Task polling finished, because all subtasks successfully finished.
TaskResult(result=True, sub_tasks_data=[SubTaskData(status='Success', status_id='success', action='lxc_delete', activity=['[26-Apr-2024 0:39:31 PDT] Application Delete action submitted for execution', '[26-Apr-2024 0:39:31 PDT] Executing device action Application Delete', '[26-Apr-2024 0:39:31 PDT] Delete virtual image', '[26-Apr-2024 0:39:31 PDT] Removing virtual image UTD-Snort-Feature-1.0.0_SV3.1.67.0_XE17.14', '[26-Apr-2024 0:39:35 PDT] Virtual image UTD-Snort-Feature-1.0.0_SV3.1.67.0_XE17.14 removed'], current_activity='Done - Application Delete', action_config='{"devices":{"deviceIP":"172.10.10.44","deviceId":"C8500L-8S4X-FLX260400ZG","installImages":[{"networkFunctionType":"app-hosting","versionTypeName":"UTD-Snort-Feature","versionName":"1.0.0_SV3.1.67.0_XE17.14"}]}}', order=16, uuid='C8500L-8S4X-FLX260400ZG', hostname='pm1044', site_id='600010044')])
>>> 
```