### PR TITLE
introduce find method for DataSequence

### DIFF
--- a/catalystwan/tests/test_typed_list.py
+++ b/catalystwan/tests/test_typed_list.py
@@ -365,6 +365,38 @@ class TestDataSequence(TestCase):
         with self.assertRaises(AttributeError):
             self.data_sequence.filter(does_not="exists")
 
+    def test_find(self):
+        # Arrange
+        expected = self.data_sequence.filter(username="User3").single_or_default()
+        # Act
+        observed = self.data_sequence.find(username="User3")
+
+        # Assert
+        self.assertEqual(observed, expected)
+
+    def test_find_two_attributes(self):
+        # Arrange
+        additional_user = User(username="User1", description="ThisOne")
+        users = copy.deepcopy(self.data_sequence)
+        users.append(additional_user)
+        correct_output = additional_user
+
+        # Act
+        output = users.find(username="User1", description="ThisOne")
+
+        # Assert
+        self.assertEqual(output, correct_output)
+
+    def test_find_wrong_arg(self):
+        # Arrange, Act, Assert
+        with self.assertRaises(AttributeError):
+            self.data_sequence.find(does_not="exists")
+
+    def test_find_no_match(self):
+        # Arrange, Act, Assert
+        with self.assertRaises(InvalidOperationError):
+            self.data_sequence.find(username="NonExistingUser")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/catalystwan/typed_list.py
+++ b/catalystwan/typed_list.py
@@ -259,3 +259,20 @@ class DataSequence(TypedList[T], Generic[T]):
             raise InvalidOperationError("The input sequence contains no elements.")
 
         return self.data[0]
+
+    def find(self, **kwargs) -> T:
+        """Finds first item in sequence matching values based on attributes.
+        Works similarily as filter but assures single element is returned or raises exception.
+
+        >>> seq = DataSequence(User, [User(username="User1"), User(username="User2")])
+        >>> seq.find(username="User1")
+        User(username='User1', password=None, group=[], locale=None, description=None, resource_group=None)
+
+        Returns:
+            [T]: The single element of the input sequence.
+        """
+        annotations = set(kwargs.keys())
+        result = next(filter(lambda x: all(getattr(x, a) == kwargs[a] for a in annotations), self.data), None)
+        if result is None:
+            raise InvalidOperationError(f"Item matching {kwargs} not found in the input sequence")
+        return result


### PR DESCRIPTION
# Pull Request summary:
Introduce `find()` method for DataSequence.
It works similarily like `filter()` but iteration stops when first object in sequence is detected. It guarantees that single object is returned (when no item found exception is raised)

# Example:
```python
with create_manager_session(...) as session:
    api = session.api.sdwan_feature_profiles.system
    # before
    profile = api.get_profiles().filter(profile_name="system-1").single_or_default()
    # after (using find)
    profile = api.get_profiles().find(profile_name="system-1")
```

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
