### PR TITLE
allow disabling of response validation against pydantic model

### DIFF
--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -24,10 +24,10 @@ class APIEndpointClientResponse(Protocol):
     def content(self) -> bytes:
         ...
 
-    def dataobj(self, cls: Type[T], sourcekey: Optional[str]) -> T:
+    def dataobj(self, cls: Type[T], sourcekey: Optional[str], validate: bool) -> T:
         ...
 
-    def dataseq(self, cls: Type[T], sourcekey: Optional[str]) -> DataSequence[T]:
+    def dataseq(self, cls: Type[T], sourcekey: Optional[str], validate: bool) -> DataSequence[T]:
         ...
 
     def json(self) -> dict:
@@ -51,4 +51,8 @@ class APIEndpointClient(Protocol):
 
     @property
     def session_type(self) -> Optional[SessionType]:
+        ...
+
+    @property
+    def validate_response(self) -> bool:
         ...

--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -54,5 +54,5 @@ class APIEndpointClient(Protocol):
         ...
 
     @property
-    def validate_response(self) -> bool:
+    def validate_responses(self) -> bool:
         ...

--- a/catalystwan/endpoints/__init__.py
+++ b/catalystwan/endpoints/__init__.py
@@ -568,11 +568,11 @@ class request(APIEndpointsDecorator):
                         return response.dataseq(
                             cls=self.return_spec.payload_type,
                             sourcekey=self.resp_json_key,
-                            validate=_self._client.validate_response,
+                            validate=_self._client.validate_responses,
                         )
                     else:
                         return response.dataobj(
-                            self.return_spec.payload_type, self.resp_json_key, validate=_self._client.validate_response
+                            self.return_spec.payload_type, self.resp_json_key, validate=_self._client.validate_responses
                         )
                 elif issubclass(self.return_spec.payload_type, str):
                     return response.text

--- a/catalystwan/endpoints/__init__.py
+++ b/catalystwan/endpoints/__init__.py
@@ -565,9 +565,15 @@ class request(APIEndpointsDecorator):
                     pass
                 elif issubclass(self.return_spec.payload_type, BaseModel):
                     if self.return_spec.sequence_type == DataSequence:
-                        return response.dataseq(self.return_spec.payload_type, self.resp_json_key)
+                        return response.dataseq(
+                            cls=self.return_spec.payload_type,
+                            sourcekey=self.resp_json_key,
+                            validate=_self._client.validate_response,
+                        )
                     else:
-                        return response.dataobj(self.return_spec.payload_type, self.resp_json_key)
+                        return response.dataobj(
+                            self.return_spec.payload_type, self.resp_json_key, validate=_self._client.validate_response
+                        )
                 elif issubclass(self.return_spec.payload_type, str):
                     return response.text
                 elif issubclass(self.return_spec.payload_type, bytes):

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -153,7 +153,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         port: Optional[int] = None,
         subdomain: Optional[str] = None,
         auth: Optional[AuthBase] = None,
-        validate_response: bool = True,
+        validate_responses: bool = True,
     ):
         self.url = url
         self.port = port
@@ -178,7 +178,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         self._state: ManagerSessionState = ManagerSessionState.OPERATIVE
         self.restart_timeout: int = 1200
         self.polling_requests_timeout: int = 10
-        self._validate_response = validate_response
+        self._validate_responses = validate_responses
 
     @property
     def state(self) -> ManagerSessionState:
@@ -483,12 +483,12 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         return self._api_version
 
     @property
-    def validate_response(self) -> bool:
-        return self._validate_response
+    def validate_responses(self) -> bool:
+        return self._validate_responses
 
-    @validate_response.setter
-    def validate_response(self, value: bool):
-        self._validate_response = value
+    @validate_responses.setter
+    def validate_responses(self, value: bool):
+        self._validate_responses = value
 
     def __str__(self) -> str:
         return f"{self.username}@{self.base_url}"

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -153,6 +153,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         port: Optional[int] = None,
         subdomain: Optional[str] = None,
         auth: Optional[AuthBase] = None,
+        validate_response: bool = True,
     ):
         self.url = url
         self.port = port
@@ -177,6 +178,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         self._state: ManagerSessionState = ManagerSessionState.OPERATIVE
         self.restart_timeout: int = 1200
         self.polling_requests_timeout: int = 10
+        self._validate_response = validate_response
 
     @property
     def state(self) -> ManagerSessionState:
@@ -236,7 +238,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         try:
             server_info = self.server()
         except DefaultPasswordError:
-            server_info = ServerInfo.parse_obj({})
+            server_info = ServerInfo.model_construct(**{})
 
         self.server_name = server_info.server
 
@@ -404,7 +406,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         Returns:
             Tenant UUID.
         """
-        tenants = self.get("dataservice/tenant").dataseq(Tenant)
+        tenants = self.get("dataservice/tenant").dataseq(Tenant, validate=False)
         tenant = tenants.filter(subdomain=self.subdomain).single_or_default()
 
         if not tenant or not tenant.tenant_id:
@@ -479,6 +481,14 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
     @property
     def api_version(self) -> Version:
         return self._api_version
+
+    @property
+    def validate_response(self) -> bool:
+        return self._validate_response
+
+    @validate_response.setter
+    def validate_response(self, value: bool):
+        self._validate_response = value
 
     def __str__(self) -> str:
         return f"{self.username}@{self.base_url}"

--- a/catalystwan/tests/test_response.py
+++ b/catalystwan/tests/test_response.py
@@ -155,7 +155,6 @@ class TestResponse(unittest.TestCase):
         data = vmng_response.dataobj(DataForValidateTest, sourcekey=None, validate=False)
         # Assert
         assert isinstance(data, DataForValidateTest)
-        print(data)
         assert data.important == VALIDATE_DATASEQ_TEST_DATA[0]["important"]
         with self.assertRaises(ValidationError):
             vmng_response.dataobj(DataForValidateTest, sourcekey=None, validate=True)
@@ -167,7 +166,6 @@ class TestResponse(unittest.TestCase):
         dataseq = vmng_response.dataseq(DataForValidateTest, sourcekey=None, validate=False)
         # Assert
         assert isinstance(dataseq, DataSequence)
-        print(dataseq)
         for i, data in enumerate(dataseq):
             assert isinstance(data, DataForValidateTest)
             assert data.important == VALIDATE_DATASEQ_TEST_DATA[i]["important"]


### PR DESCRIPTION
# Pull Request summary:
User can opt-out from response validation against pydantic model.
This might be useful when `ValidationError` disrupts program flow while malformed attribute is not important to user (eg. while testing new vmanage builds with possible api changes).
This setting is available as `ManagerSession().validate_responses` property. Default is `True` so change is  not breaking.

# Description of changes:
While flag is set to `False` we use `BaseModel.model_construct()` instead `BaseModel.model_validate()`. https://docs.pydantic.dev/latest/concepts/models/#creating-models-without-validation.

This affects all responses obtained by methods from:
`ManagerSession().request().dataobj(validate=...)`
`ManagerSession().request().dataseq(validate=...)`
`ManagerSession().endpoints`

### Usage example:

```python
from catalystwan.session import create_manager_session

url = "example.com"
username = "admin"
password = "password123"

with create_manager_session(url=url, username=username, password=password) as session:
    # disable response validation
    session.validate_responses=False
    # response payload object still can be used normally unless field that is malformed is being accessed
    tenants = session.api.tenant_management.get()
    print([tenant.org_name for tenant in tenants])
```



# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
