### PR TITLE
Issue/624 - Extend variable value type

### DIFF
--- a/catalystwan/endpoints/configuration_group.py
+++ b/catalystwan/endpoints/configuration_group.py
@@ -2,7 +2,7 @@
 
 # mypy: disable-error-code="empty-body"
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -68,9 +68,12 @@ class ConfigGroupVariablesCreatePayload(BaseModel):
     suggestions: bool = True
 
 
+VariableType = Union[str, int, bool, List[Union[str, int, bool]]]
+
+
 class VariableData(BaseModel):
     name: str
-    value: str
+    value: Optional[VariableType] = None
 
 
 class DeviceVariables(BaseModel):


### PR DESCRIPTION
# Pull Request summary:
Extend variable value type by `str|int|bool|list[str|int|bool]`

# Description of changes:
Server can return more types than only str in variable value field. Pydantic validator in this case raise exception. 

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Make sure you test the changes
