### PR TITLE
Adding changes for new api

### DIFF
--- a/catalystwan/api/api_container.py
+++ b/catalystwan/api/api_container.py
@@ -24,6 +24,7 @@ from catalystwan.api.omp_api import OmpAPI
 from catalystwan.api.packet_capture_api import PacketCaptureAPI
 from catalystwan.api.partition_manager_api import PartitionManagerAPI
 from catalystwan.api.policy_api import PolicyAPI
+from catalystwan.api.real_time_monitoring_api import RealTimeMonitoringAPI
 from catalystwan.api.resource_pool_api import ResourcePoolAPI
 from catalystwan.api.software_action_api import SoftwareActionAPI
 from catalystwan.api.speedtest_api import SpeedtestAPI
@@ -68,3 +69,4 @@ class APIContainer:
         self.sessions = SessionsAPI(session)
         self.policy = PolicyAPI(session)
         self.sd_routing_feature_profiles = SDRoutingFeatureProfilesAPI(session)
+        self.realtimeapi = RealTimeMonitoringAPI(session)

--- a/catalystwan/api/real_time_monitoring_api.py
+++ b/catalystwan/api/real_time_monitoring_api.py
@@ -1,0 +1,72 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from catalystwan.session import ManagerSession
+
+
+class RealTimeMonitoringAPI:
+    """Real Time Monitoring API gathers information from Real time Monitoring page.
+
+    Attributes:
+        session (ManagerSession): logged in API client session
+
+    Usage example:
+        # Create session
+        session = create_manager_session(...)
+        # Get information about tenant status
+        tenant_status = session.api.dashboard.get_tenant_status()
+    """
+
+    def __init__(self, session: ManagerSession):
+        self.session = session
+
+    def get_bfd_summary(self, device_id) -> List:
+        """
+        Get information about bfd summary from a device.
+
+        Returns:
+            List of bfd summary
+        """
+        bfd_summary = self.session.get_data("/dataservice/device/bfd/summary?deviceId={}".format(device_id))
+
+        return bfd_summary
+
+    def get_device_status(self, device_id) -> List:
+        """
+        Get system status from a device.
+
+        Returns:
+            List of system status
+        """
+        device_status = self.session.get_data("/dataservice/device/system/status?deviceId={}".format(device_id))
+
+        return device_status
+
+    def get_hardware_status_summary(self, device_id) -> List:
+        """
+        Get hardware status summary from a device.
+
+        Returns:
+            List of hardware status.
+        """
+        device_hw = self.session.get_data("/dataservice/device/hardware/status/summary?deviceId={}".format(device_id))
+
+        return device_hw
+
+    def get_approute_trans_summary(self, site_id) -> List:
+        """
+        Get app route stats for a tunnel with loss percentage from a site.
+
+        Returns:
+            List of app route state
+        """
+        approute_summary = self.session.get_data(
+            "dataservice/statistics/approute/tunnels/health/loss_percentage?"
+            "limit=10000&last_n_hours=24&site-id={}".format(site_id)
+        )
+
+        return approute_summary


### PR DESCRIPTION
# Pull Request summary:
Adding new api call support

# Description of changes:
Adding new change for below get api call,
1. GET /dataservice/device/system/status?deviceId=1.1.1.3
2. "GET /dataservice/device/bfd/summary?deviceId=1.3.11.146
3. "GET /dataservice/device/hardware/status/summary?deviceId=1.3.19.143
4. "GET /dataservice/statistics/approute/tunnels/health/loss_percentage?limit=10000&last_n_hours=24&site-id=3000100211'

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes

Unit Test: 1st api

```
>>> session.api.realtimeapi.get_device_status(dev.filter(hostname='pm1027')[0].id)
[{'mem_used': '4463016', 'procs': '596', 'disk_avail': '3929M', 'disk_mount': '/bootflash', 'board_type': 'Vedge-ISR', 'vdevice-name': '170.16.248.27', 'total_cpu_count': '14', 'mem_cached': '3589680', 'timezone': 'PDT -0700', 'reboot_type': 'Initiated by other', 'disk_fs': '/dev/bootflash1', 'fp_cpu_count': '12', 'chassis-serial-number': 'FDO2328A1VK', 'min1_avg': '2.02', 'state_description': 'All daemons up', 'personality': 'vEdge', 'disk_used': '3041M', 'disk_use': '44', 'model': 'vedge-C8300-2N2S-6T', 'disk_status': 'enabled', 'state': 'green', 'config_date/date-time-string': 'Mon May 06 16:43:56 PDT 2024', 'linux_cpu_count': '2', 'reboot_reason': 'Image Install ', 'cpu_user': '8.01', 'testbed_mode': '0', 'min15_avg': '1.95', 'disk_size': '7341M', 'cpu_idle': '88.15', 'mem_buffers': '962416', 'model_sku': 'None', 'cpu_system': '3.82', 'version': '17.15.01.0.226', 'min5_avg': '2.05', 'tcpd_cpu_count': '0', 'vdevice-host-name': 'pm1027', 'mem_total': '15974684', 'uptime': '2 days 22 hrs 40 min 58 sec', 'vdevice-dataKey': '170.16.248.27', 'mem_free': '11511668', 'bootloader_version': 'Not applicable', 'device_role': 'cEdge-SDWAN', 'fips_mode': 'enabled', 'build_number': 'Not applicable', 'lastupdated': 1715058134829, 'loghost_status': 'disabled', 'uptime-date': 1714803660000}]
>>> 
```

Unit Test: 2nd api

```
>>> session.api.realtimeapi.get_bfd_summary(dev.filter(hostname='pm1027')[0].id)
[{'bfd-sessions-max': '82', 'vdevice-dataKey': '170.16.248.27', 'bfd-sessions-flap': '3572', 'vdevice-name': '170.16.248.27', 'bfd-sessions-up': '80', 'lastupdated': 1715058554553, 'bfd-sessions-total': '80', 'poll-interval': '20000', 'vdevice-host-name': 'pm1027'}]
>>> 
```

Unit Test: 3rd api

```
>>> session.api.realtimeapi.get_hardware_status_summary(dev.filter(hostname='pm1032')[0].id)
[{'vdevice-name': '172.10.10.32', 'createTimeStamp': 1633041809687, 'current-reading': '29', 'vdevice-host-name': 'pm1032', 'sensor-name': 'temperature', 'vdevice-dataKey': '172.10.10.32-Temp: Int4-R0', '@rid': 53939, 'vmanage-system-ip': '172.10.10.32', 'sensor-units': 'celsius', 'name': 'Temp: Int4', 'tenantId': 'default', 'lastupdated': 1714978624279, 'location': 'R0', 'state': 'Normal'}, {'vdevice-name': '172.10.10.32', 'createTimeStamp': 1633041809718, 'current-reading': '33', 'vdevice-host-name': 'pm1032', 'sensor-name': 'temperature', 'vdevice-dataKey': '172.10.10.32-Temp: CPU-R0', '@rid': 54032, 'vmanage-system-ip': '172.10.10.32', 'sensor-units': 'celsius', 'name': 'Temp: CPU', 'tenantId': 'default', 'lastupdated': 1715040261344, 'location': 'R0', 'state': 'Normal'}, {'vdevice-name': '172.10.10.32', 'createTimeStamp': 1633041809591, 'current-reading': '34', 'vdevice-host-name': 'pm1032', 'sensor-name': 'temperature', 'vdevice-dataKey': '172.10.10.32-Temp: Int1-R0', '@rid': 92877, 'vmanage-system-ip': '172.10.10.32', 'sensor-units': 'celsius', 'name': 'Temp: Int1', 'tenantId': 'default', 'lastupdated': 1715040261344, 'location': 'R0', 'state': 'Normal'}, {'vdevice-name': '172.10.10.32', 'createTimeStamp': 1633041809624, 'current-reading': '25', 'vdevice-host-name': 'pm1032', 'sensor-name': 'temperature', 'vdevice-dataKey': '172.10.10.32-Temp: Int2-R0', '@rid': 92879, 'vmanage-system-ip': '172.10.10.32', 'sensor-units': 'celsius', 'name': 'Temp: Int2', 'tenantId': 'default', 'lastupdated': 1715040261344, 'location': 'R0', 'state': 'Normal'}, {'vdevice-name': '172.10.10.32', 'createTimeStamp': 1633041809656, 'current-reading': '28', 'vdevice-host-name': 'pm1032', 'sensor-name': 'temperature', 'vdevice-dataKey': '172.10.10.32-Temp: Int3-R0', '@rid': 92881, 'vmanage-system-ip': '172.10.10.32', 'sensor-units': 'celsius', 'name': 'Temp: Int3', 'tenantId': 'default', 'lastupdated': 1715040261344, 'location': 'R0', 'state': 'Normal'}]
>>> 
```

Unit Test: 4th api

```
>>> session.api.realtimeapi.get_approute_trans_summary(dev.filter(hostname='pm1032')[0].site_id)
[{'loss_percentage': 0.091, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 9.959, 'name': '172.10.10.32:public-internet-172.17.240.63:private2', 'remote_color': 'private2', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.077, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 368180476100.0, 'rx_octets': 94049337166, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-170.16.248.28:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '170.16.248.28', 'remote-host-name': 'pm1028', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.06, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.17.240.63:private1', 'remote_color': 'private1', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.023, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 369966729984, 'rx_octets': 94504560746, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-170.16.248.28:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '170.16.248.28', 'remote-host-name': 'pm1028', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.008, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 118259368292, 'rx_octets': 18804050757, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.10.10.41:biz-internet', 'remote_color': 'biz-internet', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.007, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 118181318525, 'rx_octets': 37600719184, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.10.10.41:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.001, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.17.240.63:private2', 'remote_color': 'private2', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.10.10.42:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.10.10.42', 'remote-host-name': 'pm1042', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 126862386779, 'rx_octets': 19062535528, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.10.10.41:biz-internet', 'remote_color': 'biz-internet', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.17.240.63:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.17.240.63:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 132991188436, 'rx_octets': 37617295798, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.10.10.41:red', 'remote_color': 'red', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 134439180429, 'rx_octets': 38116658304, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.10.10.41:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 112010981021, 'rx_octets': 38119556891, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.10.10.41:red', 'remote_color': 'red', 'remote_system_ip': '172.10.10.41', 'remote-host-name': 'pm1041', 'remote_site_id': '600010028', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.32:public-internet-172.10.10.42:public-internet', 'remote_color': 'public-internet', 'remote_system_ip': '172.10.10.42', 'remote-host-name': 'pm1042', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.32', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}, {'loss_percentage': 0.0, 'latency': 0.0, 'jitter': 0.0, 'tx_octets': 0.0, 'rx_octets': 0.0, 'vqoe_score': 10.0, 'name': '172.10.10.33:public-internet-172.17.240.63:private1', 'remote_color': 'private1', 'remote_system_ip': '172.17.240.63', 'remote-host-name': 'pm1023', 'remote_site_id': '30002023', 'remote_latitude': '37.666684', 'remote_longitude': '-122.777023', 'local_color': 'public-internet', 'local_system_ip': '172.10.10.33', 'device-type': 'vedge', 'deviceClass': 'cisco-router', 'site_id': '600010032', 'state': 'Up', 'health': 'green'}]
>>> 
```