### PR TITLE
Fix ValidationError for empty dict

### DIFF
--- a/catalystwan/models/policy/definition/intrusion_prevention.py
+++ b/catalystwan/models/policy/definition/intrusion_prevention.py
@@ -3,7 +3,7 @@
 from typing import List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from catalystwan.models.common import PolicyModeType, VpnId
 from catalystwan.models.policy.policy_definition import (
@@ -34,6 +34,13 @@ class IntrusionPreventionDefinition(BaseModel):
     custom_signature: bool = Field(
         default=False, validation_alias="customSignature", serialization_alias="customSignature"
     )
+
+    @field_validator("signature_white_list", mode="before")
+    @classmethod
+    def convert_empty_dict_to_none(cls, value):
+        if not value:
+            return None
+        return value
 
 
 class IntrusionPreventionPolicy(PolicyDefinitionBase):


### PR DESCRIPTION
# Pull Request summary:
fix validation error

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for IntrusionPreventionPolicyGetResponse
definition.signatureWhiteList.ref
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```

# Description of changes:


# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
