### PR TITLE
include original cause and info from server in ManagerHTTPError traceback

### DIFF
--- a/catalystwan/exceptions.py
+++ b/catalystwan/exceptions.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 
-from typing import Any, Optional, Union
+from typing import Union
 
 from pydantic import BaseModel
 from requests import HTTPError, RequestException
@@ -19,16 +19,18 @@ class CatalystwanException(Exception):
 class ManagerRequestException(RequestException, CatalystwanException):
     """Exception raised when there is ambigous problem during sending of request to Manager"""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize RequestException with `request` and `response` objects."""
-        super().__init__(*args, **kwargs)
-
 
 class ManagerHTTPError(HTTPError, ManagerRequestException):
-    def __init__(self, *, error_info: Optional[ManagerErrorInfo], request: Any, response: Any):
+    def __init__(self, *args, error_info: ManagerErrorInfo, **kwargs):
         """Initialize RequestException with `error_info`, `request` and `response` objects."""
         self.info = error_info
-        super().__init__(request=request, response=response)
+        info_str = str(self.info)
+        _args = args
+        if not _args:
+            _args = (info_str,)
+        else:
+            _args = (str(_args[0]) + "\n" + info_str,) + _args[1:]
+        super().__init__(*_args, **kwargs)
 
 
 class DefaultPasswordError(CatalystwanException):

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -313,7 +313,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
                 continue
             except RequestException as exception:
                 self.logger.debug(self.response_trace(exception.response, exception.request))
-                raise ManagerRequestException(request=exception.request, response=exception.response)
+                raise ManagerRequestException(*exception.args)
 
         raise ManagerReadyTimeout(f"Waiting for server ready took longer than {timeout} seconds.")
 
@@ -330,7 +330,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
                 self.state = ManagerSessionState.WAIT_SERVER_READY_AFTER_RESTART
                 return self.request(method, url, *args, **kwargs)
             self.logger.debug(exception)
-            raise ManagerRequestException(request=exception.request, response=exception.response)
+            raise ManagerRequestException(*exception.args)
 
         if self.enable_relogin and response.jsessionid_expired and self.state == ManagerSessionState.OPERATIVE:
             self.logger.warning("Logging to session. Reason: expired JSESSIONID detected in response headers")
@@ -345,7 +345,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         except HTTPError as error:
             self.logger.debug(error)
             error_info = response.get_error_info()
-            raise ManagerHTTPError(error_info=error_info, request=error.request, response=error.response)
+            raise ManagerHTTPError(*error.args, error_info=error_info)
         return response
 
     def get_full_url(self, url_path: str) -> str:

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -330,7 +330,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
                 self.state = ManagerSessionState.WAIT_SERVER_READY_AFTER_RESTART
                 return self.request(method, url, *args, **kwargs)
             self.logger.debug(exception)
-            raise ManagerRequestException(*exception.args)
+            raise ManagerRequestException(*exception.args, request=exception.request, response=exception.response)
 
         if self.enable_relogin and response.jsessionid_expired and self.state == ManagerSessionState.OPERATIVE:
             self.logger.warning("Logging to session. Reason: expired JSESSIONID detected in response headers")
@@ -345,7 +345,7 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         except HTTPError as error:
             self.logger.debug(error)
             error_info = response.get_error_info()
-            raise ManagerHTTPError(*error.args, error_info=error_info)
+            raise ManagerHTTPError(*error.args, error_info=error_info, request=error.request, response=error.response)
         return response
 
     def get_full_url(self, url_path: str) -> str:


### PR DESCRIPTION
```python
from catalystwan.session import create_manager_session

with create_manager_session(...) as session:
    session.api.users.delete("bogus-user-name")
    session.put("/dataservice/settings/configuration/vedgecloud", {"certificateauthority": "enterprise"})
```

# Before:
```
Traceback (most recent call last):
  ...
catalystwan.exceptions.ManagerHTTPError
```

# After:
```
Traceback (most recent call last):
  ...
catalystwan.exceptions.ManagerHTTPError: 500 Server Error: Internal Server Error for url: https://172.22.219.19:9912/dataservice/admin/user/bogus-user-name
message='Delete users request failed' details='Failed to process device request -  Error Message : bad-element:user' code='USER0006'
```
```
Traceback (most recent call last):
  ...
catalystwan.exceptions.ManagerHTTPError: 415 Client Error: Unsupported Media Type for url: https://172.22.219.19:9912/dataservice/settings/configuration/vedgecloud
message=None details=None code=None
```

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
