### PR TITLE
alarms-20.15

### DIFF
--- a/catalystwan/api/alarms_api.py
+++ b/catalystwan/api/alarms_api.py
@@ -53,7 +53,12 @@ class AlarmsAPI:
             >>> alarms = AlarmsAPI(session).get()
             >>> critical_alarms = alarms.filter(severity=Severity.CRITICAL)
         """
-        query: Dict[str, Any] = {"query": {"condition": "AND", "rules": []}}
+        query: Dict[str, Any] = {
+            "query": {
+                "condition": "AND",
+                "rules": [{"field": "active", "type": "boolean", "value": ["true"], "operator": "equal"}],
+            }
+        }
         if from_time:
             query["query"]["rules"].append(
                 {


### PR DESCRIPTION
# Pull Request summary:
In earlier release the rules=[] were shown in docstring, but they were not required.
Now starting in 20.15 they are required.
The default rules has not changed, should be fine backward compatible.

# Description of changes:
Added a default rules=[] for alarms.
`rules = [{"field": "active", "type": "boolean", "value": ["true"], "operator": "equal"}]`

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
