### PR TITLE
dev-uxmt: add policy push reporting and context

### DIFF
--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -539,3 +539,9 @@ class PolicyConvertContext:
                 if parcel.vpn_id.value is not None:
                     context.lan_vpn_map[parcel.parcel_name] = parcel.vpn_id.value
         return context
+
+
+@dataclass
+class PolicyPushContext:
+    default_policy_object_profile_id: Optional[UUID] = None
+    id_lookup: Dict[UUID, UUID] = {}  # universal lookup for finding pushed item id by origin id

--- a/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
@@ -86,6 +86,7 @@ def as_num_ranges_list(p: str) -> List[Union[int, Tuple[int, int]]]:
     """
     applicable to acl source/destination port list
     "1 2-5 6 7 20-22" -> [1 (2,5) 6 7 (20,22)]
+
     """
     num_list: List[Union[int, Tuple[int, int]]] = []
     for val in p.split():

--- a/catalystwan/utils/config_migration/creators/config_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_pusher.py
@@ -55,7 +55,6 @@ class UX2ConfigPusher:
     def push(self) -> UX2ConfigPushResult:
         self._create_cloud_credentials()
         self._create_config_groups()
-
         self._policy_object_pusher.push()
         dpop = self._policy_object_pusher.get_or_create_default_policy_object_profile()
         self._create_topology_groups(dpop)  # needs to be executed after vpn parcels and groups of interests are created

--- a/catalystwan/utils/config_migration/creators/policy_object_pusher.py
+++ b/catalystwan/utils/config_migration/creators/policy_object_pusher.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from catalystwan.api.feature_profile_api import PolicyObjectFeatureProfileAPI
 from catalystwan.exceptions import ManagerHTTPError
-from catalystwan.models.configuration.config_migration import UX2Config, UX2ConfigPushResult
+from catalystwan.models.configuration.config_migration import PolicyPushContext, UX2Config, UX2ConfigPushResult
 from catalystwan.models.configuration.feature_profile.common import FeatureProfileCreationPayload, RefIdItem
 from catalystwan.models.configuration.feature_profile.parcel import AnyParcel, Parcel, list_types
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import (
@@ -119,23 +119,26 @@ class PolicyObjectPusher:
         ux2_config: UX2Config,
         session: ManagerSession,
         push_result: UX2ConfigPushResult,
+        push_context: PolicyPushContext,
         progress: Callable[[str, int, int], None],
     ) -> None:
         self._ux2_config = ux2_config
         self._policy_object_api: PolicyObjectFeatureProfileAPI = session.api.sdwan_feature_profiles.policy_object
         self._push_result: UX2ConfigPushResult = push_result
         self._progress: Callable[[str, int, int], None] = progress
-        self._pushed_objects_map: Dict[UUID, UUID] = {}
+        self.push_context = push_context
 
     def push(self):
-        default_profile_id = self.get_or_create_default_policy_object_profile()
-        self.push_groups_of_interests_objects(default_profile_id)
+        profile_id = self.push_context.default_policy_object_profile_id
+        self.push_context.default_policy_object_profile_id = profile_id
+        self.push_groups_of_interests_objects(profile_id)
 
-    def push_groups_of_interests_objects(self, default_profile_id: UUID):
+    def push_groups_of_interests_objects(self):
         # TODO: fix typing issues in this method, probably we need literal containig AnyPolicyObjectType type_
         def cast_(parcel: AnyParcel) -> AnyPolicyObjectParcel:
             return parcel  # type: ignore
 
+        default_profile_id = self.push_context.default_policy_object_profile_id
         profile_rollback = self._push_result.rollback.add_default_policy_object_profile_id(default_profile_id)
 
         # will hold system created parcels id by type and name when detected
@@ -173,12 +176,12 @@ class PolicyObjectPusher:
                 continue
 
             try:
-                update_parcels_references(parcel, self._pushed_objects_map)
+                update_parcels_references(parcel, self.push_context.id_lookup)
 
                 parcel_id = self._policy_object_api.create(profile_id=default_profile_id, payload=parcel).id
                 profile_rollback.add_parcel(parcel.type_, parcel_id)
                 self._push_result.report.groups_of_interest.add_created(parcel.parcel_name, parcel_id)
-                self._pushed_objects_map[transformed_parcel.header.origin] = parcel_id
+                self.push_context.id_lookup[transformed_parcel.header.origin] = parcel_id
 
                 self._progress(
                     f"Creating Policy Object Parcel: {parcel.parcel_name}",

--- a/catalystwan/utils/config_migration/creators/policy_object_pusher.py
+++ b/catalystwan/utils/config_migration/creators/policy_object_pusher.py
@@ -136,7 +136,7 @@ class PolicyObjectPusher:
         def cast_(parcel: AnyParcel) -> AnyPolicyObjectParcel:
             return parcel  # type: ignore
 
-        profile_rollback = self._push_result.rollback.add_default_policy_object_profile(default_profile_id)
+        profile_rollback = self._push_result.rollback.add_default_policy_object_profile_id(default_profile_id)
 
         # will hold system created parcels id by type and name when detected
         system_created_parcels: Dict[Type[AnyPolicyObjectParcel], Dict[str, UUID]] = {}

--- a/catalystwan/utils/config_migration/creators/policy_object_pusher.py
+++ b/catalystwan/utils/config_migration/creators/policy_object_pusher.py
@@ -1,12 +1,12 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Dict, Mapping, Type, cast
+from typing import Callable, Dict, Mapping, Optional, Type, cast
 from uuid import UUID
 
 from catalystwan.api.feature_profile_api import PolicyObjectFeatureProfileAPI
 from catalystwan.exceptions import ManagerHTTPError
-from catalystwan.models.configuration.config_migration import PolicyPushContext, UX2Config, UX2ConfigPushResult
+from catalystwan.models.configuration.config_migration import PushContext, UX2Config, UX2ConfigPushResult
 from catalystwan.models.configuration.feature_profile.common import FeatureProfileCreationPayload, RefIdItem
 from catalystwan.models.configuration.feature_profile.parcel import AnyParcel, Parcel, list_types
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import (
@@ -119,7 +119,7 @@ class PolicyObjectPusher:
         ux2_config: UX2Config,
         session: ManagerSession,
         push_result: UX2ConfigPushResult,
-        push_context: PolicyPushContext,
+        push_context: PushContext,
         progress: Callable[[str, int, int], None],
     ) -> None:
         self._ux2_config = ux2_config
@@ -129,16 +129,19 @@ class PolicyObjectPusher:
         self.push_context = push_context
 
     def push(self):
-        profile_id = self.push_context.default_policy_object_profile_id
+        profile_id = self.get_or_create_default_policy_object_profile()
         self.push_context.default_policy_object_profile_id = profile_id
-        self.push_groups_of_interests_objects(profile_id)
+        self.push_groups_of_interests_objects()
 
     def push_groups_of_interests_objects(self):
-        # TODO: fix typing issues in this method, probably we need literal containig AnyPolicyObjectType type_
+        default_profile_id = self.push_context.default_policy_object_profile_id
+        if default_profile_id is None:
+            logger.error("Cannot create Groups of Interest without Default Policy Object Profile")
+            return
+
         def cast_(parcel: AnyParcel) -> AnyPolicyObjectParcel:
             return parcel  # type: ignore
 
-        default_profile_id = self.push_context.default_policy_object_profile_id
         profile_rollback = self._push_result.rollback.add_default_policy_object_profile_id(default_profile_id)
 
         # will hold system created parcels id by type and name when detected
@@ -172,7 +175,7 @@ class PolicyObjectPusher:
                     system_created_parcels[parcel_type][ep.payload.parcel_name] = id_
 
             # if parcel with given name exists we skip it
-            if system_created_parcels[parcel_type].get(header.origname or ""):  # changed
+            if system_created_parcels[parcel_type].get(header.origname or ""):
                 continue
 
             try:
@@ -192,11 +195,16 @@ class PolicyObjectPusher:
                 logger.error(f"Error occured during config group creation: {e.info}")
                 self._push_result.report.groups_of_interest.add_failed(parcel, e)
 
-    def get_or_create_default_policy_object_profile(self) -> UUID:
+    def get_or_create_default_policy_object_profile(self) -> Optional[UUID]:
         profiles = self._policy_object_api.get_profiles()
         if len(profiles) >= 1:
             return profiles[0].profile_id
-        profile_id = self._policy_object_api.create_profile(
-            FeatureProfileCreationPayload(name="Policy_Profile_Global", description="Policy_Profile_Global_description")
-        ).id
+        try:
+            profile_id = self._policy_object_api.create_profile(
+                FeatureProfileCreationPayload(
+                    name="Policy_Profile_Global", description="Policy_Profile_Global_description"
+                )
+            ).id
+        except ManagerHTTPError:
+            profile_id = None
         return profile_id


### PR DESCRIPTION
# Pull Request summary:
- add `TopologyGroup` and `PolicyGroup` reporting
- add `PushContext` object which will contain various items updated during push process (currently it stores id lookup needed to find pushed item id by its origin id)

Note: Topology push is currently in draft, dedicated pusher will be created (it is used to fill report for quick UI integration with config-migration-tool) 


# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
