### PR TITLE
dev-uxmt: Fix: Add interface name converter to ethernet

### DIFF
--- a/catalystwan/tests/config_migration/test_utils.py
+++ b/catalystwan/tests/config_migration/test_utils.py
@@ -1,0 +1,25 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+from catalystwan.utils.config_migration.converters.utils import convert_interface_name
+
+
+def test_convert_interface_name_when_name_in_mapping_expect_correct_covert():
+    in_ = ["ge0/2", "ge2/0/1", "ge1/1/1"]
+    expected_out = [
+        "GigabitEthernet0/2",
+        "GigabitEthernet2/0/1",
+        "GigabitEthernet1/1/1",
+    ]
+
+    for i, o in zip(in_, expected_out):
+        assert convert_interface_name(i) == o
+
+
+def test_convert_interface_name_when_name_not_in_mapping_expect_same_name():
+    in_ = [
+        "xe0/2",
+        "ATM0/2",
+        "Vlan1",
+    ]
+
+    for i in in_:
+        assert convert_interface_name(i) == i

--- a/catalystwan/tests/config_migration/test_utils.py
+++ b/catalystwan/tests/config_migration/test_utils.py
@@ -3,12 +3,8 @@ from catalystwan.utils.config_migration.converters.utils import convert_interfac
 
 
 def test_convert_interface_name_when_name_in_mapping_expect_correct_covert():
-    in_ = ["ge0/2", "ge2/0/1", "ge1/1/1"]
-    expected_out = [
-        "GigabitEthernet0/2",
-        "GigabitEthernet2/0/1",
-        "GigabitEthernet1/1/1",
-    ]
+    in_ = ["ge0/2", "ge2/0/1", "ge1/1/1", "eth0", "eth0/1/1"]
+    expected_out = ["GigabitEthernet0/2", "GigabitEthernet2/0/1", "GigabitEthernet1/1/1", "Ethernet0", "Ethernet0/1/1"]
 
     for i, o in zip(in_, expected_out):
         assert convert_interface_name(i) == o

--- a/catalystwan/utils/config_migration/converters/feature_template/bgp.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/bgp.py
@@ -1,5 +1,4 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
 import logging
 from copy import deepcopy
 from ipaddress import IPv4Interface

--- a/catalystwan/utils/config_migration/converters/feature_template/bgp.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/bgp.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 import logging
 from copy import deepcopy
@@ -98,8 +99,6 @@ class BgpRoutingTemplateConverter:
         if not neighbors:
             return None
 
-        print(neighbors)
-
         items = []
         for neighbor in neighbors:
             address = neighbor.get("address")
@@ -148,7 +147,6 @@ class BgpRoutingTemplateConverter:
                     **family,
                 )
             )
-        print(len(items))
         return items
 
     def parse_neighbor_ipv6(self, neighbors: List[Dict]) -> Optional[List[Ipv6NeighborItem]]:

--- a/catalystwan/utils/config_migration/converters/feature_template/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/ethernet.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 from ipaddress import IPv6Interface
 from typing import Dict, List, Optional, Union
 
@@ -22,6 +22,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.transport.management
     StaticIPv6AddressConfig,
 )
 from catalystwan.utils.config_migration.converters.feature_template.helpers import create_dict_without_none
+from catalystwan.utils.config_migration.converters.utils import convert_interface_name
 from catalystwan.utils.config_migration.steps.constants import MANAGEMENT_VPN_ETHERNET
 
 
@@ -33,7 +34,7 @@ class ManagementInterfaceEthernetTemplateConverter:
             parcel_name=name,
             parcel_description=description,
             advanced=self.parse_advanced(template_values),
-            interface_name=template_values.get("if_name"),
+            interface_name=as_global(convert_interface_name(template_values["if_name"].value)),
             interface_description=template_values.get("description", Default[None](value=None)),
             intf_ip_address=self.parse_ipv4_address(template_values),
             shutdown=template_values.get("shutdown"),

--- a/catalystwan/utils/config_migration/converters/feature_template/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/ethernet.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
+from copy import deepcopy
 from ipaddress import IPv6Interface
 from typing import Dict, List, Optional, Union
 
@@ -22,7 +23,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.transport.management
     StaticIPv6AddressConfig,
 )
 from catalystwan.utils.config_migration.converters.feature_template.helpers import create_dict_without_none
-from catalystwan.utils.config_migration.converters.utils import convert_interface_name
+from catalystwan.utils.config_migration.converters.utils import parse_interface_name
 from catalystwan.utils.config_migration.steps.constants import MANAGEMENT_VPN_ETHERNET
 
 
@@ -30,19 +31,21 @@ class ManagementInterfaceEthernetTemplateConverter:
     supported_template_types = (MANAGEMENT_VPN_ETHERNET,)
 
     def create_parcel(self, name: str, description: str, template_values: dict) -> InterfaceEthernetParcel:
+        data = deepcopy(template_values)
+
         payload = create_dict_without_none(
             parcel_name=name,
             parcel_description=description,
-            advanced=self.parse_advanced(template_values),
-            interface_name=as_global(convert_interface_name(template_values["if_name"].value)),
-            interface_description=template_values.get("description", Default[None](value=None)),
-            intf_ip_address=self.parse_ipv4_address(template_values),
-            shutdown=template_values.get("shutdown"),
-            arp=self.parse_arp(template_values),
-            auto_detect_bandwidth=template_values.get("auto_bandwidth_detect"),
-            dhcp_helper=template_values.get("dhcp_helper"),
-            intf_ip_v6_address=self.parse_ipv6_address(template_values),
-            iperf_server=template_values.get("iperf_server"),
+            advanced=self.parse_advanced(data),
+            interface_name=parse_interface_name(data),
+            interface_description=data.get("description", Default[None](value=None)),
+            intf_ip_address=self.parse_ipv4_address(data),
+            shutdown=data.get("shutdown"),
+            arp=self.parse_arp(data),
+            auto_detect_bandwidth=data.get("auto_bandwidth_detect"),
+            dhcp_helper=data.get("dhcp_helper"),
+            intf_ip_v6_address=self.parse_ipv6_address(data),
+            iperf_server=data.get("iperf_server"),
         )
 
         return InterfaceEthernetParcel(**payload)

--- a/catalystwan/utils/config_migration/converters/feature_template/lan/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/lan/ethernet.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 from copy import deepcopy
 from typing import Dict, List, Optional
 
@@ -26,6 +26,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.service.lan.ethernet
     Trustsec,
     VrrpIPv4,
 )
+from catalystwan.utils.config_migration.converters.utils import convert_interface_name
 from catalystwan.utils.config_migration.steps.constants import LAN_VPN_ETHERNET
 
 
@@ -114,6 +115,7 @@ class LanInterfaceEthernetTemplateConverter:
     def configure_interface_name(self, values: dict) -> None:
         if if_name := values.get("if_name"):
             values["interface_name"] = if_name
+            values["interface_name"] = as_global(convert_interface_name(if_name.value))
 
     def configure_ethernet_description(self, values: dict) -> None:
         values["ethernet_description"] = values.get("description")

--- a/catalystwan/utils/config_migration/converters/feature_template/lan/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/lan/ethernet.py
@@ -26,7 +26,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.service.lan.ethernet
     Trustsec,
     VrrpIPv4,
 )
-from catalystwan.utils.config_migration.converters.utils import convert_interface_name
+from catalystwan.utils.config_migration.converters.utils import parse_interface_name
 from catalystwan.utils.config_migration.steps.constants import LAN_VPN_ETHERNET
 
 
@@ -113,9 +113,7 @@ class LanInterfaceEthernetTemplateConverter:
         return {"parcel_name": name, "parcel_description": description, **values}
 
     def configure_interface_name(self, values: dict) -> None:
-        if if_name := values.get("if_name"):
-            values["interface_name"] = if_name
-            values["interface_name"] = as_global(convert_interface_name(if_name.value))
+        values["interface_name"] = parse_interface_name(values)
 
     def configure_ethernet_description(self, values: dict) -> None:
         values["ethernet_description"] = values.get("description")

--- a/catalystwan/utils/config_migration/converters/feature_template/wan/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/wan/ethernet.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
 from copy import deepcopy
 from typing import Dict, List, Optional, Union
@@ -30,6 +30,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.transport.wan.interf
     Tunnel,
 )
 from catalystwan.utils.config_migration.converters.feature_template.helpers import create_dict_without_none
+from catalystwan.utils.config_migration.converters.utils import convert_interface_name
 from catalystwan.utils.config_migration.steps.constants import WAN_VPN_ETHERNET
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ class WanInterfaceEthernetTemplateConverter:
 
         encapsulation = self.parse_encapsulations(data.get("tunnel_interface", {}).get("encapsulation", []))
         interface_name = data["if_name"]
+        interface_name = as_global(convert_interface_name(interface_name.value))
         interface_description = data.get(
             "description", as_global(description)
         )  # Edge case where model doesn't have description but its required

--- a/catalystwan/utils/config_migration/converters/feature_template/wan/ethernet.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/wan/ethernet.py
@@ -30,7 +30,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.transport.wan.interf
     Tunnel,
 )
 from catalystwan.utils.config_migration.converters.feature_template.helpers import create_dict_without_none
-from catalystwan.utils.config_migration.converters.utils import convert_interface_name
+from catalystwan.utils.config_migration.converters.utils import parse_interface_name
 from catalystwan.utils.config_migration.steps.constants import WAN_VPN_ETHERNET
 
 logger = logging.getLogger(__name__)
@@ -43,8 +43,7 @@ class WanInterfaceEthernetTemplateConverter:
         data = deepcopy(template_values)
 
         encapsulation = self.parse_encapsulations(data.get("tunnel_interface", {}).get("encapsulation", []))
-        interface_name = data["if_name"]
-        interface_name = as_global(convert_interface_name(interface_name.value))
+        interface_name = parse_interface_name(data)
         interface_description = data.get(
             "description", as_global(description)
         )  # Edge case where model doesn't have description but its required

--- a/catalystwan/utils/config_migration/converters/utils.py
+++ b/catalystwan/utils/config_migration/converters/utils.py
@@ -1,7 +1,17 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 import re
 
 NEGATIVE_VARIABLE_REGEX = re.compile(r"[^.\/\[\]a-zA-Z0-9_-]")
 
+INTERFACE_NAME_MAPPING = {"ge": "GigabitEthernet"}
+
 
 def convert_varname(orig: str) -> str:
     return NEGATIVE_VARIABLE_REGEX.sub("_", orig)
+
+
+def convert_interface_name(if_name: str) -> str:
+    for key, value in INTERFACE_NAME_MAPPING.items():
+        if if_name.startswith(key):
+            return value + if_name[len(key) :]
+    return if_name

--- a/catalystwan/utils/config_migration/converters/utils.py
+++ b/catalystwan/utils/config_migration/converters/utils.py
@@ -1,9 +1,19 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
+import logging
 import re
+from typing import Dict, Union
+
+from catalystwan.api.configuration_groups.parcel import Global, Variable, as_global
+from catalystwan.utils.config_migration.converters.exceptions import CatalystwanConverterCantConvertException
+
+logger = logging.getLogger(__name__)
 
 NEGATIVE_VARIABLE_REGEX = re.compile(r"[^.\/\[\]a-zA-Z0-9_-]")
 
-INTERFACE_NAME_MAPPING = {"ge": "GigabitEthernet"}
+INTERFACE_NAME_MAPPING = {
+    "ge": "GigabitEthernet",
+    "eth": "Ethernet",
+}
 
 
 def convert_varname(orig: str) -> str:
@@ -13,5 +23,16 @@ def convert_varname(orig: str) -> str:
 def convert_interface_name(if_name: str) -> str:
     for key, value in INTERFACE_NAME_MAPPING.items():
         if if_name.startswith(key):
-            return value + if_name[len(key) :]
+            new_if_name = value + if_name[len(key) :]
+            logger.info(f"Converted interface name: {if_name} -> {new_if_name}")
+            return new_if_name
     return if_name
+
+
+def parse_interface_name(data: Dict) -> Union[Global[str], Variable]:
+    if_name = data.get("if_name")
+    if isinstance(if_name, Variable):
+        return if_name
+    elif isinstance(if_name, Global):
+        return as_global(convert_interface_name(if_name.value))
+    raise CatalystwanConverterCantConvertException("Interface name is required")


### PR DESCRIPTION
# Pull Request summary:
Convert UX1.0 ethernet interface names to conform to UX2.0 regex

- eth -> Ethernet
- ge -> GigabitEthernet

# Description of changes:
Cover case where templates created by system have interface name that don't pass regex 

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
