### PR TITLE
Move away from enums

### DIFF
--- a/catalystwan/api/templates/cli_template.py
+++ b/catalystwan/api/templates/cli_template.py
@@ -1,5 +1,4 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
 
 from __future__ import annotations
 

--- a/catalystwan/api/templates/cli_template.py
+++ b/catalystwan/api/templates/cli_template.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 
 from __future__ import annotations
@@ -13,7 +14,6 @@ from requests.exceptions import HTTPError
 
 from catalystwan.dataclasses import Device
 from catalystwan.exceptions import TemplateTypeError
-from catalystwan.utils.device_model import DeviceModel
 from catalystwan.utils.template_type import TemplateType
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ class CLITemplate:
             "templateId": id,
             "templateName": self.template_name,
             "templateDescription": self.template_description,
-            "deviceType": self.device_model.value,
+            "deviceType": self.device_model,
             "templateConfiguration": config_str,
             "factoryDefault": False,
             "configType": "file",
@@ -149,7 +149,6 @@ class CLITemplate:
         >>> a_conf = CiscoConfParse(a)
         >>> b_conf = CiscoConfParse(b)
         >>> compare = TemplateAPI.compare_template(a_conf, b_conf full=True)
-        >>> print(compare)
           !
             tacacs
             server 192.168.1.1
@@ -193,7 +192,6 @@ class CLITemplate:
         >>> a_conf = CiscoConfParse(a)
         >>> device = DevicesAPI(API_SESSION).get(DeviceField.HOSTNAME, device_name)
         >>> compare = TemplateAPI.compare_template(a_conf, device, full=True)
-        >>> print(compare)
         .
         .
         .

--- a/catalystwan/api/templates/cli_template.py
+++ b/catalystwan/api/templates/cli_template.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class CLITemplate:
     template_name: str
     template_description: str
-    device_model: DeviceModel
+    device_model: str
     config: CiscoConfParse = CiscoConfParse([], factory=True)
 
     def load(self, session: ManagerSession, id: str) -> CiscoConfParse:
@@ -67,16 +67,15 @@ class CLITemplate:
         payload = {
             "templateName": self.template_name,
             "templateDescription": self.template_description,
-            "deviceType": self.device_model.value,
+            "deviceType": self.device_model,
             "templateConfiguration": config_str,
             "factoryDefault": False,
             "configType": "file",
         }
         if self.device_model not in [
-            DeviceModel.VEDGE,
-            DeviceModel.VSMART,
-            DeviceModel.VMANAGE,
-            DeviceModel.VBOND,
+            "vedge-cloud",
+            "vsmart",
+            "vmanage",
         ]:
             payload["cliType"] = "device"
             payload["draftMode"] = False


### PR DESCRIPTION
# Pull Request summary:
Change device_model to str

# Description of changes:
```python
from catalystwan.api.templates.cli_template import CLITemplate
from catalystwan.utils.device_model import DeviceModel
import requests
from catalystwan.session import create_manager_session

# Disable warnings about insecure requests (self-signed certificates, etc.)
requests.packages.urllib3.disable_warnings()

# Replace with your vManage details
VMANAGE_URL = 'https://vmanage-url'
USERNAME = 'your-username'
PASSWORD = 'your-password'
DEVICE_HOSTNAME = 'vm1'
TEMPLATE_NAME = 'template_test'

# Establish a session with vManage
with create_manager_session(url=VMANAGE_URL, username=USERNAME, password=PASSWORD) as session:
    
    # Step 1: Get the running configuration of the device
    devices = session.api.devices.get()
    device = devices.filter(hostname=DEVICE_HOSTNAME).single_or_default(default=None)
    
    if device:
        # Step 2: Create a CLI Template with the running config
        cli_template = CLITemplate(
            template_name=TEMPLATE_NAME,
            template_description="CLI Template",
            device_model=device.model,
        )
        cli_template.load_running(session, device)
        session.api.templates.create(cli_template)
        # Step 3: Attach the template to the device
        session.api.templates.attach(TEMPLATE_NAME, device)
        
        print(f"CLI Template created and attached to device {DEVICE_HOSTNAME}.")
    else:
        print(f"Device with hostname {DEVICE_HOSTNAME} not found.") 
```

Following script throws en error:

```
Traceback (most recent call last):
  File "/home/jakub/data.py", line 37, in <module>
    session.api.templates.create(cli_template)
  File "/home/jakub/work/catalystwan/catalystwan/api/template_api.py", line 431, in create
    template_id = self._create_cli_template(template)
  File "/home/jakub/work/catalystwan/catalystwan/api/template_api.py", line 448, in _create_cli_template
    payload = template.generate_payload()
  File "/home/jakub/work/catalystwan/catalystwan/api/templates/cli_template.py", line 70, in generate_payload
    "deviceType": self.device_model.value,
AttributeError: 'str' object has no attribute 'value'
```

Since device has an str instead of Enum

```python
@define
class Device(DataclassBase):
    uuid: str
    personality: Personality = field(converter=Personality)
    ...
    model: Optional[str] = field(default=None, metadata={FIELD_NAME: "device-model"})
    ...
```

# Checklist:
- [ ] Make sure to run pre-commit before committing changes
- [ ] Make sure all checks have passed
- [ ] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [ ] Make sure you test the changes
