### PR TITLE
hotfix: tenacity 8.4.0 issue

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,6 +1,6 @@
 **THIS FILE WAS AUTO-GENERATED DO NOT EDIT**
 
-Generated for: catalystwan-0.33.8
+Generated for: catalystwan-0.33.9
 
 All URIs are relative to */dataservice*
 HTTP request | Supported Versions | Method | Payload Type | Return Type | Tenancy Mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.33.8"
+version = "0.33.9"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
`tenacity==8.4.0` cannot be used as dependency as it causes issues with python 3.11
please see:
https://github.com/jd/tenacity/issues/471

Bump version

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
