### PR TITLE
dev-uxmt: additional convert result handling and reporting

### DIFF
--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -608,3 +608,7 @@ class ConvertResult(Generic[TO]):
     status: ConvertStatus = "complete"
     output: Optional[TO] = None
     info: List[str] = field(default_factory=list)
+
+    def update_status(self, status: ConvertStatus, message: str):
+        self.status = status
+        self.info.append(message)

--- a/catalystwan/tests/config_migration/policy_converters/test_acl_ipv4.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_acl_ipv4.py
@@ -56,7 +56,7 @@ class TestDeviceAccessIPv4Converter(unittest.TestCase):
         inseq.associate_policer_list_action(policer_list_id=exp_action_policer_list_id)
 
         # Act
-        outs = convert(in_=ins, uuid=uuid4(), context=self.context)
+        outs = convert(in_=ins, uuid=uuid4(), context=self.context).output
 
         # Assert
         assert isinstance(outs, Ipv4AclParcel)
@@ -117,7 +117,7 @@ class TestDeviceAccessIPv4Converter(unittest.TestCase):
         inseq.associate_log_action()
 
         # Act
-        outs = convert(in_=ins, uuid=uuid4(), context=self.context)
+        outs = convert(in_=ins, uuid=uuid4(), context=self.context).output
 
         # Assert
         assert isinstance(outs, Ipv4AclParcel)

--- a/catalystwan/tests/config_migration/policy_converters/test_acl_ipv6.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_acl_ipv6.py
@@ -58,7 +58,7 @@ class TestDeviceAccessIPv6Converter(unittest.TestCase):
         inseq.associate_traffic_class_action(traffic_class=exp_action_traffic_class)
 
         # Act
-        outs = convert(in_=ins, uuid=uuid4(), context=self.context)
+        outs = convert(in_=ins, uuid=uuid4(), context=self.context).output
 
         # Assert
         assert isinstance(outs, Ipv6AclParcel)
@@ -119,7 +119,7 @@ class TestDeviceAccessIPv6Converter(unittest.TestCase):
         inseq.associate_log_action()
 
         # Act
-        outs = convert(in_=ins, uuid=uuid4(), context=self.context)
+        outs = convert(in_=ins, uuid=uuid4(), context=self.context).output
 
         # Assert
         assert isinstance(outs, Ipv6AclParcel)

--- a/catalystwan/tests/config_migration/policy_converters/test_aip_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_aip_converter.py
@@ -3,6 +3,9 @@ import unittest
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.aip import (
+    AdvancedInspectionProfileParcel,
+)
 from catalystwan.models.policy.definition.aip import (
     AdvancedInspectionProfileDefinition,
     AdvancedInspectionProfilePolicy,
@@ -35,8 +38,9 @@ class TestAdvancedInspectionProfileParcel(unittest.TestCase):
         )
         uuid = uuid4()
         # Act
-        parcel = convert(aip, uuid, context=self.context)
+        parcel = convert(aip, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, AdvancedInspectionProfileParcel)
         assert parcel.parcel_name == "aip"
         assert parcel.parcel_description == "test_description"
         assert parcel.tls_decryption_action.value == "skipDecrypt"

--- a/catalystwan/tests/config_migration/policy_converters/test_amp_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_amp_converter.py
@@ -2,6 +2,9 @@ import unittest
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.amp import (
+    AdvancedMalwareProtectionParcel,
+)
 from catalystwan.models.policy.definition.amp import (
     AdvancedMalwareProtectionDefinition,
     AdvancedMalwareProtectionPolicy,
@@ -31,8 +34,9 @@ class TestAdvancedMalwareProtectionConverter(unittest.TestCase):
         )
 
         uuid = uuid4()
-        parcel = convert(amp_v1_entry, uuid, context=self.context)
+        parcel = convert(amp_v1_entry, uuid, context=self.context).output
 
+        assert isinstance(parcel, AdvancedMalwareProtectionParcel)
         assert parcel.parcel_name == "amp_security"
         assert parcel.match_all_vpn.value is False
         assert parcel.file_reputation_cloud_server.value == "eur"
@@ -63,8 +67,9 @@ class TestAdvancedMalwareProtectionConverter(unittest.TestCase):
         )
 
         uuid = uuid4()
-        parcel = convert(amp_v1_entry, uuid, context=self.context)
+        parcel = convert(amp_v1_entry, uuid, context=self.context).output
 
+        assert isinstance(parcel, AdvancedMalwareProtectionParcel)
         assert parcel.parcel_name == "amp_unified"
         assert parcel.match_all_vpn.value is True
         assert parcel.file_reputation_cloud_server.value == "eur"
@@ -93,8 +98,9 @@ class TestAdvancedMalwareProtectionConverter(unittest.TestCase):
         )
 
         uuid = uuid4()
-        parcel = convert(amp_v1_entry, uuid, context=self.context)
+        parcel = convert(amp_v1_entry, uuid, context=self.context).output
 
+        assert isinstance(parcel, AdvancedMalwareProtectionParcel)
         assert parcel.parcel_name == "amp_empty_literals"
         assert parcel.match_all_vpn.value is True
         assert parcel.file_reputation_cloud_server.value == "eur"

--- a/catalystwan/tests/config_migration/policy_converters/test_device_access_ipv4.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_device_access_ipv4.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import unittest
 from ipaddress import IPv4Interface
-from typing import cast
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
@@ -39,8 +38,9 @@ class TestDeviceAccessIPv4Converter(unittest.TestCase):
         policy.sequences.append(seq)
         uuid = uuid4()
         # Act
-        parcel = cast(DeviceAccessIPv4Parcel, convert(policy, uuid, context=self.context))
+        parcel = convert(policy, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, DeviceAccessIPv4Parcel)
         assert parcel.parcel_name == "device_access_ipv4"
         assert parcel.parcel_description == "test_description"
         assert parcel.default_action.value == "drop"
@@ -81,8 +81,9 @@ class TestDeviceAccessIPv4Converter(unittest.TestCase):
         policy.sequences.append(seq)
         uuid = uuid4()
         # Act
-        parcel = cast(DeviceAccessIPv4Parcel, convert(policy, uuid, context=self.context))
+        parcel = convert(policy, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, DeviceAccessIPv4Parcel)
         assert parcel.parcel_name == "device_access_ipv4"
         assert parcel.parcel_description == "test_description"
         assert parcel.default_action.value == "drop"

--- a/catalystwan/tests/config_migration/policy_converters/test_device_access_ipv6.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_device_access_ipv6.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import unittest
 from ipaddress import IPv6Interface
-from typing import cast
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
@@ -42,8 +41,9 @@ class TestDeviceAccessIpv6Converter(unittest.TestCase):
         policy.sequences.append(seq)
         uuid = uuid4()
         # Act
-        parcel = cast(DeviceAccessIPv6Parcel, convert(policy, uuid, context=self.context))
+        parcel = convert(policy, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, DeviceAccessIPv6Parcel)
         assert parcel.parcel_name == "device_access_ipv6"
         assert parcel.parcel_description == "test_description"
         assert parcel.default_action.value == "drop"
@@ -84,8 +84,9 @@ class TestDeviceAccessIpv6Converter(unittest.TestCase):
         policy.sequences.append(seq)
         uuid = uuid4()
         # Act
-        parcel = cast(DeviceAccessIPv6Parcel, convert(policy, uuid, context=self.context))
+        parcel = convert(policy, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, DeviceAccessIPv6Parcel)
         assert parcel.parcel_name == "device_access_ipv6"
         assert parcel.parcel_description == "test_description"
         assert parcel.default_action.value == "drop"

--- a/catalystwan/tests/config_migration/policy_converters/test_dns_security_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_dns_security_converter.py
@@ -2,6 +2,7 @@ import unittest
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.dns_security.dns import DnsParcel
 from catalystwan.models.policy.definition.dns_security import DnsSecurityDefinition, DnsSecurityPolicy, TargetVpn
 from catalystwan.models.policy.policy_definition import Reference
 from catalystwan.utils.config_migration.converters.policy.policy_definitions import convert
@@ -26,8 +27,9 @@ class TestDnsSecurityConverter(unittest.TestCase):
             ),
         )
 
-        parcel = convert(policy, self.uuid, self.context)
+        parcel = convert(policy, self.uuid, self.context).output
 
+        assert isinstance(parcel, DnsParcel)
         assert parcel.parcel_name == "test1"
         assert parcel.parcel_description == "destription 1"
         assert parcel.child_org_id is None
@@ -54,8 +56,9 @@ class TestDnsSecurityConverter(unittest.TestCase):
             ),
         )
 
-        parcel = convert(policy, self.uuid, self.context)
+        parcel = convert(policy, self.uuid, self.context).output
 
+        assert isinstance(parcel, DnsParcel)
         assert parcel.parcel_name == "test2"
         assert parcel.child_org_id.value == str(12345)
         assert parcel.dns_crypt.value is False
@@ -82,8 +85,9 @@ class TestDnsSecurityConverter(unittest.TestCase):
             ),
         )
 
-        parcel = convert(policy, self.uuid, self.context)
+        parcel = convert(policy, self.uuid, self.context).output
 
+        assert isinstance(parcel, DnsParcel)
         assert parcel.parcel_name == "test3"
         assert parcel.child_org_id.value == str(65645645)
         assert parcel.dns_crypt.value is False
@@ -111,8 +115,9 @@ class TestDnsSecurityConverter(unittest.TestCase):
             ),
         )
 
-        parcel = convert(policy, self.uuid, self.context)
+        parcel = convert(policy, self.uuid, self.context).output
 
+        assert isinstance(parcel, DnsParcel)
         assert parcel.parcel_name == "test4"
         assert parcel.child_org_id is None
         assert parcel.dns_crypt.value is True

--- a/catalystwan/tests/config_migration/policy_converters/test_extended_community_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_extended_community_converter.py
@@ -1,10 +1,7 @@
 import unittest
 
 from catalystwan.models.policy.list.communities import ExtendedCommunityList
-from catalystwan.utils.config_migration.converters.policy.policy_lists import (
-    CatalystwanConverterCantConvertException,
-    extended_community,
-)
+from catalystwan.utils.config_migration.converters.policy.policy_lists import extended_community
 
 
 class TestExtendedCommunityConverter(unittest.TestCase):
@@ -13,7 +10,8 @@ class TestExtendedCommunityConverter(unittest.TestCase):
         community_list.add_route_target_community(100, 1000)
         community_list.add_site_of_origin_community("1.2.3.4", 1000)
 
-        extended_community_parcel = extended_community(community_list, None)
+        extended_community_parcel = extended_community(community_list, None).output
+        assert extended_community_parcel is not None
 
         assert len(extended_community_parcel.entries) == 2
         assert extended_community_parcel.entries[0].extended_community.value == "rt 100:1000"
@@ -24,7 +22,8 @@ class TestExtendedCommunityConverter(unittest.TestCase):
         community_list.add_route_target_community(123, 1234, name="dummy prefix")
         community_list.add_site_of_origin_community("1.2.3.4", 2000, name="community")
 
-        extended_community_parcel = extended_community(community_list, None)
+        extended_community_parcel = extended_community(community_list, None).output
+        assert extended_community_parcel is not None
 
         assert len(extended_community_parcel.entries) == 2
         assert extended_community_parcel.entries[0].extended_community.value == "rt 123:1234"
@@ -34,5 +33,5 @@ class TestExtendedCommunityConverter(unittest.TestCase):
         community_list = ExtendedCommunityList(name="ext_community_1")
         community_list.add_site_of_origin_community("1:2:3::5", 2000, name="community")
 
-        with self.assertRaises(CatalystwanConverterCantConvertException):
-            extended_community(community_list, None)
+        result = extended_community(community_list, None)
+        assert result.status == "failed"

--- a/catalystwan/tests/config_migration/policy_converters/test_intrusion_prevention.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_intrusion_prevention.py
@@ -3,6 +3,9 @@ import unittest
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.intrusion_prevention import (
+    IntrusionPreventionParcel,
+)
 from catalystwan.models.policy.definition.intrusion_prevention import (
     IntrusionPreventionDefinition,
     IntrusionPreventionPolicy,
@@ -31,8 +34,9 @@ class TestIntrusionPreventionConverter(unittest.TestCase):
         )
         uuid = uuid4()
         # Act
-        parcel = convert(ipp, uuid, context=self.context)
+        parcel = convert(ipp, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, IntrusionPreventionParcel)
         assert parcel.parcel_name == "ip_unified"
         assert parcel.signature_set.value == "balanced"
         assert parcel.inspection_mode.value == "detection"
@@ -59,9 +63,10 @@ class TestIntrusionPreventionConverter(unittest.TestCase):
         )
         uuid = uuid4()
         # Act
-        parcel = convert(ipp, uuid, context=self.context)
+        parcel = convert(ipp, uuid, context=self.context).output
 
         # Assert
+        assert isinstance(parcel, IntrusionPreventionParcel)
         assert parcel.parcel_name == "ip_security"
         assert parcel.signature_set.value == "connectivity"
         assert parcel.inspection_mode.value == "protection"

--- a/catalystwan/tests/config_migration/policy_converters/test_mirror_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_mirror_converter.py
@@ -14,7 +14,7 @@ class TestMirrorConverter(unittest.TestCase):
             ],
         )
 
-        v2_parcel = mirror(mirror_v1, context=None)
+        v2_parcel = mirror(mirror_v1, context=None).output
 
         assert type(v2_parcel) is MirrorParcel
 
@@ -26,6 +26,6 @@ class TestMirrorConverter(unittest.TestCase):
             ],
         )
 
-        v2_parcel = mirror(mirror_v1, context=None)
+        v2_parcel = mirror(mirror_v1, context=None).output
 
         assert type(v2_parcel) is MirrorParcel

--- a/catalystwan/tests/config_migration/policy_converters/test_route_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_route_converter.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import unittest
 from ipaddress import IPv4Address
-from typing import cast
 from uuid import uuid4
 
 from catalystwan.api.configuration_groups.parcel import as_global
@@ -104,8 +103,9 @@ class TestRoutePolicyConverter(unittest.TestCase):
         )
 
         # Act
-        parcel = cast(RoutePolicyParcel, convert(route_policy, uuid, context=self.context))
+        parcel = convert(route_policy, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, RoutePolicyParcel)
         assert parcel.parcel_name == "test_route_policy"
         assert parcel.parcel_description == "description"
         assert parcel.default_action.value == "accept"

--- a/catalystwan/tests/config_migration/policy_converters/test_ssl_decryption_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_ssl_decryption_converter.py
@@ -4,6 +4,9 @@ from uuid import uuid4
 
 from catalystwan.models.common import VpnId
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.ssl_decryption import (
+    SslDecryptionParcel,
+)
 from catalystwan.models.policy.definition.ssl_decryption import (
     CaCertBundle,
     ControlPolicyBaseAction,
@@ -50,8 +53,9 @@ class TestSslDecryptionConverter(unittest.TestCase):
         uuid = uuid4()
 
         # Act
-        parcel = convert(ssl_decryption_v1_entry, uuid, context=self.context)
+        parcel = convert(ssl_decryption_v1_entry, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, SslDecryptionParcel)
         assert parcel.parcel_name == "ssl_decryption"
         assert parcel.parcel_description == "test_description"
         assert parcel.ssl_enable.value is True
@@ -99,8 +103,9 @@ class TestSslDecryptionConverter(unittest.TestCase):
         uuid = uuid4()
 
         # Act
-        parcel = convert(ssl_decryption_v1_entry, uuid, context=self.context)
+        parcel = convert(ssl_decryption_v1_entry, uuid, context=self.context).output
         # # Assert
+        assert isinstance(parcel, SslDecryptionParcel)
         assert parcel.ca_cert_bundle.default.value is False
         assert parcel.ca_cert_bundle.file_name.value == "certificate.ca-bundle"
         assert parcel.ca_cert_bundle.bundle_string.value == "fdsfsdfsdfsd\nfsfs\n\n"

--- a/catalystwan/tests/config_migration/policy_converters/test_ssl_profile_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_ssl_profile_converter.py
@@ -4,6 +4,9 @@ from uuid import uuid4
 
 from catalystwan.api.configuration_groups.parcel import as_global
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.ssl_decryption_profile import (
+    SslDecryptionProfileParcel,
+)
 from catalystwan.models.policy.definition.ssl_decryption_utd_profile import (
     SslDecryptionUtdProfileDefinition,
     SslDecryptionUtdProfilePolicy,
@@ -40,8 +43,9 @@ class TestSslDecryptionConverter(unittest.TestCase):
         )
         uuid = uuid4()
         # Act
-        parcel = convert(ssl_decryption_profile, uuid, context=self.context)
+        parcel = convert(ssl_decryption_profile, uuid, context=self.context).output
         # Assert
+        assert isinstance(parcel, SslDecryptionProfileParcel)
         assert parcel.parcel_name == "ssl_decryption"
         assert parcel.parcel_description == "test_description"
         assert parcel.decrypt_categories.value == ["auctions", "computer-and-internet-security"]

--- a/catalystwan/tests/test_url_filtering_converter.py
+++ b/catalystwan/tests/test_url_filtering_converter.py
@@ -2,6 +2,9 @@ import unittest
 from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.url_filtering import (
+    UrlFilteringParcel,
+)
 from catalystwan.models.policy.definition.url_filtering import (
     BLOCK_PAGE_CONTENT_HEADER,
     UrlFilteringDefinition,
@@ -32,8 +35,9 @@ class TestUrlFilteringConverter(unittest.TestCase):
             ),
         )
 
-        parcel = url_filtering(policy, uuid=self.uuid, context=self.context)
+        parcel = url_filtering(policy, uuid=self.uuid, context=self.context).output
 
+        assert isinstance(parcel, UrlFilteringParcel)
         assert parcel.parcel_name == "policy1"
         assert parcel.web_reputation.value == "trustworthy"
         assert parcel.web_categories_action.value == "allow"
@@ -64,8 +68,9 @@ class TestUrlFilteringConverter(unittest.TestCase):
             ),
         )
 
-        parcel = url_filtering(policy, uuid=self.uuid, context=self.context)
+        parcel = url_filtering(policy, uuid=self.uuid, context=self.context).output
 
+        assert isinstance(parcel, UrlFilteringParcel)
         assert parcel.parcel_name == "policy2"
         assert parcel.web_reputation.value == "suspicious"
         assert parcel.web_categories_action.value == "allow"
@@ -97,8 +102,9 @@ class TestUrlFilteringConverter(unittest.TestCase):
             ),
         )
 
-        parcel = url_filtering(policy, uuid=self.uuid, context=self.context)
+        parcel = url_filtering(policy, uuid=self.uuid, context=self.context).output
 
+        assert isinstance(parcel, UrlFilteringParcel)
         assert parcel.parcel_name == "policy3"
         assert parcel.web_reputation.value == "high-risk"
         assert parcel.web_categories_action.value == "block"

--- a/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
@@ -225,11 +225,16 @@ def hubspoke(in_: HubAndSpokePolicy, uuid: UUID, context: PolicyConvertContext) 
 def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> ConvertResult[Ipv4AclParcel]:
     out = Ipv4AclParcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
+    result = ConvertResult[Ipv4AclParcel](output=out)
     for in_seq in in_.sequences:
         out_seq = out.add_sequence(name=in_seq.sequence_name, id_=in_seq.sequence_id, base_action=in_seq.base_action)
         for in_entry in in_seq.match.entries:
             if in_entry.field == "class":
-                logger.warning(f"{out.type_} has no field matching '{in_entry.field}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains entry "
+                    f"{in_entry.field} = {in_entry.ref} which cannot be converted",
+                )
 
             if in_entry.field == "destinationDataPrefixList" and in_entry.ref:
                 out_seq.match_destination_data_prefix_list(in_entry.ref[0])
@@ -256,7 +261,11 @@ def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> ConvertResult[Ipv4AclParcel]
                     out_seq.match_packet_length((low, hi))
 
             elif in_entry.field == "plp":
-                logger.warning(f"{out.type_} has no field matching '{in_entry.field}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains entry "
+                    f"{in_entry.field} = {in_entry.value} which cannot be converted",
+                )
 
             elif in_entry.field == "protocol":
                 protocols: List[int] = []
@@ -295,7 +304,11 @@ def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> ConvertResult[Ipv4AclParcel]
             elif in_action.type == "count":
                 out_seq.associate_counter_action(name=in_action.parameter)
             elif in_action.type == "class":
-                logger.warning(f"{out.type_} has no field matching '{in_action.type}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains action "
+                    f"{in_action.type} = {in_action.parameter} which cannot be converted",
+                )
             elif in_action.type == "log":
                 out_seq.associate_log_action()
             elif in_action.type == "mirror":
@@ -303,17 +316,22 @@ def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> ConvertResult[Ipv4AclParcel]
             elif in_action.type == "policer":
                 out_seq.associate_policer_action(in_action.parameter.ref)
 
-    return ConvertResult[Ipv4AclParcel](output=out)
+    return result
 
 
 def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[Ipv6AclParcel]:
     out = Ipv6AclParcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
+    result = ConvertResult[Ipv6AclParcel](output=out)
     for in_seq in in_.sequences:
         out_seq = out.add_sequence(name=in_seq.sequence_name, id_=in_seq.sequence_id, base_action=in_seq.base_action)
         for in_entry in in_seq.match.entries:
             if in_entry.field == "class":
-                logger.warning(f"{out.type_} has no field matching '{in_entry.field}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains entry "
+                    f"{in_entry.field} = {in_entry.ref} which cannot be converted",
+                )
 
             if in_entry.field == "destinationDataIpv6PrefixList" and in_entry.ref:
                 out_seq.match_destination_data_prefix_list(in_entry.ref[0])
@@ -326,7 +344,11 @@ def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Co
                 out_seq.match_destination_ports(portlist)
 
             elif in_entry.field == "nextHeader":
-                logger.warning(f"{out.type_} has no field matching '{in_entry.field}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains entry "
+                    f"{in_entry.field} = {in_entry.value} which cannot be converted",
+                )
 
             elif in_entry.field == "packetLength":
                 low, hi = int_range_str_validator(in_entry.value, False)
@@ -336,7 +358,11 @@ def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Co
                     out_seq.match_packet_length((low, hi))
 
             elif in_entry.field == "plp":
-                logger.warning(f"{out.type_} has no field matching '{in_entry.field}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains entry "
+                    f"{in_entry.field} = {in_entry.value} which cannot be converted",
+                )
 
             elif in_entry.field == "sourceDataIpv6PrefixList" and in_entry.ref:
                 out_seq.match_source_data_prefix_list(in_entry.ref[0])
@@ -364,7 +390,11 @@ def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Co
             elif in_action.type == "count":
                 out_seq.associate_counter_action(name=in_action.parameter)
             elif in_action.type == "class":
-                logger.warning(f"{out.type_} has no field matching '{in_action.type}' found in {in_.type}: {in_.name}")
+                result.update_status(
+                    "partial",
+                    f"sequence[{in_seq.sequence_id}] contains action "
+                    f"{in_action.type} = {in_action.parameter} which cannot be converted",
+                )
             elif in_action.type == "log":
                 out_seq.associate_log_action()
             elif in_action.type == "mirror":
@@ -372,7 +402,7 @@ def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Co
             elif in_action.type == "policer":
                 out_seq.associate_policer_action(in_action.parameter.ref)
 
-    return ConvertResult[Ipv6AclParcel](output=out)
+    return result
 
 
 def device_access_ipv6(

--- a/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_definitions.py
@@ -1,15 +1,16 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, ValidationError
 from typing_extensions import Annotated
 
 from catalystwan.api.configuration_groups.parcel import as_global
 from catalystwan.models.common import DeviceAccessProtocolPort, int_range_str_validator
 from catalystwan.models.configuration.config_migration import (
+    ConvertResult,
     PolicyConvertContext,
     SslDecryptioneResidues,
     SslProfileResidues,
@@ -70,8 +71,9 @@ from catalystwan.utils.config_migration.converters.utils import convert_varname
 
 logger = logging.getLogger(__name__)
 
+
 Input = AnyPolicyDefinition
-Output = Optional[
+OutputItem = Optional[
     Annotated[
         Union[
             CustomControlParcel,
@@ -93,6 +95,8 @@ Output = Optional[
         Field(discriminator="type_"),
     ]
 ]
+OPD = TypeVar("OPD", OutputItem, None)
+Output = ConvertResult[OPD]
 
 
 def _get_parcel_name_desc(policy_definition: AnyPolicyDefinition) -> Dict[str, Any]:
@@ -142,26 +146,37 @@ def conditional_split(s: str, seps: List[str]) -> List[str]:
 
 def advanced_malware_protection(
     in_: AdvancedMalwareProtectionPolicy, uuid: UUID, context: PolicyConvertContext
-) -> AdvancedMalwareProtectionParcel:
-    if not in_.definition.file_reputation_alert:
-        raise CatalystwanConverterCantConvertException("AMP file reputation alert shall not be an empty str.")
-
+) -> ConvertResult[AdvancedMalwareProtectionParcel]:
     if vpn_list := in_.definition.target_vpns:
         context.amp_target_vpns_id[uuid] = vpn_list
-
+    if not in_.definition.file_reputation_alert:
+        return ConvertResult[AdvancedMalwareProtectionParcel](
+            status="failed", info=["AMP file reputation alert shall not be an empty str."]
+        )
     definition_dump = in_.definition.model_dump(exclude={"target_vpns"})
-    return AdvancedMalwareProtectionParcel.create(**_get_parcel_name_desc(in_), **definition_dump)
+    return ConvertResult[AdvancedMalwareProtectionParcel](
+        output=AdvancedMalwareProtectionParcel.create(**_get_parcel_name_desc(in_), **definition_dump)
+    )
 
 
-def control(in_: ControlPolicy, uuid: UUID, context) -> CustomControlParcel:
-    if not context:
-        raise CatalystwanConverterCantConvertException(f"Additional context required for {ControlPolicy.__name__}")
-    out = CustomControlParcel(**_get_parcel_name_desc(in_))
+def control(in_: ControlPolicy, uuid: UUID, context) -> ConvertResult[CustomControlParcel]:
+    # out = CustomControlParcel(**_get_parcel_name_desc(in_))
     # TODO: convert definition
-    return out
+    return ConvertResult[CustomControlParcel](output=None, status="unsupported")
 
 
-def dns_security(in_: DnsSecurityPolicy, uuid: UUID, context: PolicyConvertContext) -> DnsParcel:
+def dns_security(in_: DnsSecurityPolicy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[DnsParcel]:
+    errors: List[str] = []
+
+    def target_vpn_convert(target_vpn: TargetVpn, vpn_id_to_map: Dict[Union[str, int], List[str]]) -> TargetVpns:
+        vpn_names = []
+        for vpn in target_vpn.vpns:
+            if not (mapped_name := vpn_id_to_map.get(vpn)):
+                errors.append(f"Cannot find TargetVPN with id: {vpn}")
+            else:
+                vpn_names.extend(mapped_name)
+        return TargetVpns.create(**target_vpn.model_dump(exclude={"vpns"}), vpns=vpn_names)
+
     vpn_id_to_map = context.get_vpn_id_to_vpn_name_map()
 
     if umbrella_data := in_.definition.umbrella_data:
@@ -177,26 +192,20 @@ def dns_security(in_: DnsSecurityPolicy, uuid: UUID, context: PolicyConvertConte
         in_.definition.local_domain_bypass_list.ref if in_.definition.local_domain_bypass_list else None
     )
 
-    return DnsParcel.create(
-        **_get_parcel_name_desc(in_),
-        **in_.definition.model_dump(exclude={"local_domain_bypass_list", "umbrella_data", "target_vpns"}),
-        target_vpns=_target_vpns,
-        local_domain_bypass_list=_local_domain_bypass_list,
+    result = ConvertResult[DnsParcel](
+        output=DnsParcel.create(
+            **_get_parcel_name_desc(in_),
+            **in_.definition.model_dump(exclude={"local_domain_bypass_list", "umbrella_data", "target_vpns"}),
+            target_vpns=_target_vpns,
+            local_domain_bypass_list=_local_domain_bypass_list,
+        ),
+        info=errors,
+        status="failed" if errors else "complete",
     )
+    return result
 
 
-def target_vpn_convert(target_vpn: TargetVpn, vpn_id_to_map: Dict[Union[str, int], List[str]]) -> TargetVpns:
-    vpn_names = []
-    for vpn in target_vpn.vpns:
-        if not (mapped_name := vpn_id_to_map.get(vpn)):
-            raise CatalystwanConverterCantConvertException(f"Cannot find the TargetVPN with id: {vpn}")
-
-        vpn_names.extend(mapped_name)
-
-    return TargetVpns.create(**target_vpn.model_dump(exclude={"vpns"}), vpns=vpn_names)
-
-
-def hubspoke(in_: HubAndSpokePolicy, uuid: UUID, context: PolicyConvertContext) -> HubSpokeParcel:
+def hubspoke(in_: HubAndSpokePolicy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[HubSpokeParcel]:
     target_vpns = context.lan_vpns_by_list_id[in_.definition.vpn_list]
     out = HubSpokeParcel(**_get_parcel_name_desc(in_))
     out.target.vpn.value.extend(target_vpns)
@@ -210,10 +219,10 @@ def hubspoke(in_: HubAndSpokePolicy, uuid: UUID, context: PolicyConvertContext) 
         ospoke = out.add_spoke(isubdef.name, list(set(osites)))
         ospoke.add_hub_site(list(set(ohubs)), 1)
         out.selected_hubs.value = list(set(ohubs))
-    return out
+    return ConvertResult[HubSpokeParcel](output=out)
 
 
-def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> Ipv4AclParcel:
+def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> ConvertResult[Ipv4AclParcel]:
     out = Ipv4AclParcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
     for in_seq in in_.sequences:
@@ -294,10 +303,10 @@ def ipv4acl(in_: AclPolicy, uuid: UUID, context) -> Ipv4AclParcel:
             elif in_action.type == "policer":
                 out_seq.associate_policer_action(in_action.parameter.ref)
 
-    return out
+    return ConvertResult[Ipv4AclParcel](output=out)
 
 
-def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Ipv6AclParcel:
+def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[Ipv6AclParcel]:
     out = Ipv6AclParcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
     for in_seq in in_.sequences:
@@ -363,12 +372,12 @@ def ipv6acl(in_: AclIPv6Policy, uuid: UUID, context: PolicyConvertContext) -> Ip
             elif in_action.type == "policer":
                 out_seq.associate_policer_action(in_action.parameter.ref)
 
-    return out
+    return ConvertResult[Ipv6AclParcel](output=out)
 
 
 def device_access_ipv6(
     in_: DeviceAccessIPv6Policy, uuid: UUID, context: PolicyConvertContext
-) -> DeviceAccessIPv6Parcel:
+) -> ConvertResult[DeviceAccessIPv6Parcel]:
     out = DeviceAccessIPv6Parcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
     for in_seq in in_.sequences:
@@ -398,10 +407,12 @@ def device_access_ipv6(
                 seq.match_source_data_prefixes([IPv6Interface(v) for v in s_network_ipv6])
             elif in_entry.field == "sourcePort":
                 seq.match_source_ports(as_num_list(as_num_ranges_list(in_entry.value)))
-    return out
+    return ConvertResult[DeviceAccessIPv6Parcel](output=out)
 
 
-def device_access_ipv4(in_: DeviceAccessPolicy, uuid: UUID, context: PolicyConvertContext) -> DeviceAccessIPv4Parcel:
+def device_access_ipv4(
+    in_: DeviceAccessPolicy, uuid: UUID, context: PolicyConvertContext
+) -> ConvertResult[DeviceAccessIPv4Parcel]:
     out = DeviceAccessIPv4Parcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
     for in_seq in in_.sequences:
@@ -434,10 +445,10 @@ def device_access_ipv4(in_: DeviceAccessPolicy, uuid: UUID, context: PolicyConve
                     seq.match_source_data_prefix_variable(convert_varname(in_entry.vip_variable_name))
             elif in_entry.field == "sourcePort":
                 seq.match_source_ports(as_num_list(as_num_ranges_list(in_entry.value)))
-    return out
+    return ConvertResult[DeviceAccessIPv4Parcel](output=out)
 
 
-def route(in_: RoutePolicy, uuid: UUID, context: PolicyConvertContext) -> RoutePolicyParcel:
+def route(in_: RoutePolicy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[RoutePolicyParcel]:
     out = RoutePolicyParcel(**_get_parcel_name_desc(in_))
     out.set_default_action(in_.default_action.type)
     for in_seq in in_.sequences:
@@ -518,10 +529,10 @@ def route(in_: RoutePolicy, uuid: UUID, context: PolicyConvertContext) -> RouteP
                             out_seq.associate_ipv4_next_hop_action(in_param.value)
                         if isinstance(in_param.value, IPv6Address):
                             out_seq.associate_ipv6_next_hop_action(in_param.value)
-    return out
+    return ConvertResult[RoutePolicyParcel](output=out)
 
 
-def mesh(in_: MeshPolicy, uuid: UUID, context: PolicyConvertContext) -> MeshParcel:
+def mesh(in_: MeshPolicy, uuid: UUID, context: PolicyConvertContext) -> ConvertResult[MeshParcel]:
     target_vpns = context.lan_vpns_by_list_id[in_.definition.vpn_list]
     mesh_sites: List[str] = []
     for region in in_.definition.regions:
@@ -530,10 +541,12 @@ def mesh(in_: MeshPolicy, uuid: UUID, context: PolicyConvertContext) -> MeshParc
     out = MeshParcel(**_get_parcel_name_desc(in_))
     out.target.vpn.value = target_vpns
     out.sites.value = mesh_sites
-    return out
+    return ConvertResult[MeshParcel](output=out)
 
 
-def ssl_decryption(in_: SslDecryptionPolicy, uuid: UUID, context: PolicyConvertContext) -> SslDecryptionParcel:
+def ssl_decryption(
+    in_: SslDecryptionPolicy, uuid: UUID, context: PolicyConvertContext
+) -> ConvertResult[SslDecryptionParcel]:
     definition_dump = in_.definition.settings.model_dump(
         exclude={"certificate_lifetime", "ca_cert_bundle", "unknown_status"}
     )
@@ -550,18 +563,19 @@ def ssl_decryption(in_: SslDecryptionPolicy, uuid: UUID, context: PolicyConvertC
             sequences=in_.definition.sequences, profiles=in_.definition.profiles
         )
 
-    return SslDecryptionParcel.create(
+    out = SslDecryptionParcel.create(
         **_get_parcel_name_desc(in_),
         **definition_dump,
         ca_cert_bundle=ca_cert_bundle,
         certificate_lifetime=certificate_lifetime,
         unknown_status=unknown_status,
     )
+    return ConvertResult[SslDecryptionParcel](output=out)
 
 
 def ssl_profile(
     in_: SslDecryptionUtdProfilePolicy, uuid: UUID, context: PolicyConvertContext
-) -> SslDecryptionProfileParcel:
+) -> ConvertResult[SslDecryptionProfileParcel]:
     definition_dump = in_.definition.model_dump(
         exclude={"filtered_url_white_list", "filtered_url_black_list", "url_white_list", "url_black_list"}
     )
@@ -575,17 +589,18 @@ def ssl_profile(
             filtered_url_white_list=in_.definition.filtered_url_white_list,
         )
 
-    return SslDecryptionProfileParcel.create(
+    out = SslDecryptionProfileParcel.create(
         **_get_parcel_name_desc(in_),
         **definition_dump,
         url_allowed_list=url_allowed_list,
         url_blocked_list=url_blocked_list,
     )
+    return ConvertResult[SslDecryptionProfileParcel](output=out)
 
 
 def advanced_inspection_profile(
     in_: AdvancedInspectionProfilePolicy, uuid: UUID, context: PolicyConvertContext
-) -> AdvancedInspectionProfileParcel:
+) -> ConvertResult[AdvancedInspectionProfileParcel]:
     intrusion_prevention_ref = in_.definition.intrusion_prevention.ref if in_.definition.intrusion_prevention else None
     url_filtering_ref = in_.definition.url_filtering.ref if in_.definition.url_filtering else None
     advanced_malware_protection_ref = (
@@ -595,7 +610,7 @@ def advanced_inspection_profile(
         in_.definition.ssl_utd_decrypt_profile.ref if in_.definition.ssl_utd_decrypt_profile else None
     )
 
-    return AdvancedInspectionProfileParcel.create(
+    out = AdvancedInspectionProfileParcel.create(
         **_get_parcel_name_desc(in_),
         tls_decryption_action=in_.definition.tls_decryption_action,
         intrusion_prevention=intrusion_prevention_ref,
@@ -603,9 +618,12 @@ def advanced_inspection_profile(
         advanced_malware_protection=advanced_malware_protection_ref,
         ssl_decryption_profile=ssl_decryption_profile_ref,
     )
+    return ConvertResult[AdvancedInspectionProfileParcel](output=out)
 
 
-def url_filtering(in_: UrlFilteringPolicy, uuid: UUID, context: PolicyConvertContext) -> UrlFilteringParcel:
+def url_filtering(
+    in_: UrlFilteringPolicy, uuid: UUID, context: PolicyConvertContext
+) -> ConvertResult[UrlFilteringParcel]:
     block_page_action_map: Dict[str, BlockPageAction] = {"text": "text", "redirectUrl": "redirect-url"}
     definition_dump = in_.definition.model_dump(
         exclude={"target_vpns", "url_white_list", "url_black_list", "logging", "block_page_action"}
@@ -631,12 +649,12 @@ def url_filtering(in_: UrlFilteringPolicy, uuid: UUID, context: PolicyConvertCon
         url_allowed_list=url_allowed_list,
         url_blocked_list=url_blocked_list,
     )
-    return out
+    return ConvertResult[UrlFilteringParcel](output=out)
 
 
 def intrusion_prevention(
     in_: IntrusionPreventionPolicy, uuid: UUID, context: PolicyConvertContext
-) -> IntrusionPreventionParcel:
+) -> ConvertResult[IntrusionPreventionParcel]:
     if vpn_list := in_.definition.target_vpns:
         context.intrusion_prevention_target_vpns_id[uuid] = vpn_list
 
@@ -644,11 +662,12 @@ def intrusion_prevention(
     signature_white_list = definition_dump.pop("signature_white_list", None)
     signature_allowed_list = signature_white_list.get("ref") if signature_white_list else None
 
-    return IntrusionPreventionParcel.create(
+    out = IntrusionPreventionParcel.create(
         **_get_parcel_name_desc(in_),
         **definition_dump,
         signature_allowed_list=signature_allowed_list,
     )
+    return ConvertResult[IntrusionPreventionParcel](output=out)
 
 
 CONVERTERS: Mapping[Type[Input], Callable[..., Output]] = {
@@ -670,8 +689,9 @@ CONVERTERS: Mapping[Type[Input], Callable[..., Output]] = {
 }
 
 
-def _not_supported(in_: Input, *args, **kwargs) -> None:
+def _not_supported(in_: Input, *args, **kwargs) -> ConvertResult[None]:
     logger.warning(f"Not Supported Conversion of Policy Definition: '{in_.type}' '{in_.name}'")
+    return ConvertResult[None](status="unsupported")
 
 
 def _find_converter(in_: Input) -> Callable[..., Output]:
@@ -683,6 +703,10 @@ def _find_converter(in_: Input) -> Callable[..., Output]:
 
 def convert(in_: Input, uuid: UUID, context: PolicyConvertContext) -> Output:
     result = _find_converter(in_)(in_, uuid, context)
-    if result is not None:
-        result.model_validate(result)
+    if result.output is not None:
+        try:
+            result.output.model_validate(result.output)
+        except ValidationError as e:
+            result.status = "failed"
+            result.info.append(str(e))
     return result

--- a/catalystwan/utils/config_migration/converters/policy/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_lists.py
@@ -380,9 +380,9 @@ def zone(in_: ZoneList, context) -> ConvertResult[SecurityZoneListParcel]:
     return ConvertResult[SecurityZoneListParcel](output=out, status="complete")
 
 
-OP = TypeVar("OP", AnyPolicyObjectParcel, None)
+OPL = TypeVar("OPL", AnyPolicyObjectParcel, None)
 Input = AnyPolicyList
-Output = ConvertResult[OP]
+Output = ConvertResult[OPL]
 
 
 CONVERTERS: Mapping[Type[Input], Callable[..., Output]] = {

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -398,22 +398,27 @@ def transform(ux1: UX1Config, add_suffix: bool = True) -> ConfigTransformResult:
 
     # Policy Lists
     for policy_list in ux1.policies.policy_lists:
-        try:
-            pl_parcel = convert_policy_list(policy_list, policy_context)
-            if pl_parcel is not None:
-                header = TransformHeader(
-                    type=pl_parcel._get_parcel_type(), origin=policy_list.list_id, origname=policy_list.name
-                )
-                ux2.profile_parcels.append(TransformedParcel(header=header, parcel=pl_parcel))
-        except CatalystwanConverterCantConvertException as e:
-            exception_message = (
-                f"Policy List {policy_list.type} {policy_list.list_id} {policy_list.name}" f"was not converted: {e}"
+        pl_result = convert_policy_list(policy_list, policy_context)
+        pl_parcel = pl_result.output
+        pl_status = pl_result.status
+        if pl_status == "unsupported":
+            transform_result.add_unsupported_item(
+                name=policy_list.name, uuid=policy_list.list_id, type=policy_list.type
             )
-            logger.warning(exception_message)
+        elif pl_status == "failed":
             transform_result.add_failed_conversion_parcel(
-                exception_message=exception_message,
+                exception_message="\n".join(pl_result.info),
                 policy=policy_list,
             )
+        elif pl_parcel is not None:
+            header = TransformHeader(
+                type=pl_parcel._get_parcel_type(),
+                origin=policy_list.list_id,
+                origname=policy_list.name,
+                status=pl_status,
+                info=pl_result.info,
+            )
+            ux2.profile_parcels.append(TransformedParcel(header=header, parcel=pl_parcel))
 
     # Policy Definitions
     for policy_definition in ux1.policies.policy_definitions:
@@ -426,6 +431,10 @@ def transform(ux1: UX1Config, add_suffix: bool = True) -> ConfigTransformResult:
                     origname=policy_definition.name,
                 )
                 ux2.profile_parcels.append(TransformedParcel(header=header, parcel=pd_parcel))
+            else:
+                transform_result.add_unsupported_item(
+                    name=policy_definition.name, uuid=policy_definition.definition_id, type=policy_definition.type
+                )
         except CatalystwanConverterCantConvertException as e:
             exception_message = (
                 f"Policy Definition {policy_definition.type} {policy_definition.definition_id} {policy_definition.name}"


### PR DESCRIPTION
# Pull Request summary:
Currently when converting an item result can by only pass (output item is provided) or fail (no output item is provided)
This PR introduces more options to better track and report unsupported or partially converted items.

# Description of changes:
This PR introduces:
```python
TO = TypeVar("TO")

ConvertOutputStatus = Literal["complete", "partial"]
ConvertAbortStatus = Literal["failed", "unsupported"]
ConvertStatus = Literal[ConvertOutputStatus, ConvertAbortStatus]

@dataclass
class ConvertResult(Generic[TO]):
    status: ConvertStatus = "complete"
    output: Optional[TO] = None
    info: List[str] = field(default_factory=list)
```
`ConvertResult` is generic type that wraps conversion output with additional data which can be provided by converter.
Another change is `ConfigTransformResult` contains additional field `unsupportedConversionItems` which should be populated with info for each unsupported item which was not converted.

`ConvertResult` also removes need to use `CatalystwanConverterCantConvertException` with try/catch block, as fail result could be provided in regular flow.

## Usage example
### Before
```python
def color(in_: ColorList, context) -> ColorParcel:
    out = ColorParcel(**_get_parcel_name_desc(in_))
    for entry in in_.entries:
        out.add_color(entry.color)
    return out
```
### After
```python
def color(in_: ColorList, context) -> ConvertResult[ColorParcel]:
    out = ColorParcel(**_get_parcel_name_desc(in_))
    for entry in in_.entries:
        out.add_color(entry.color)
    return ConvertResult[ColorParcel](output=out, status="complete")
```

## Reporting
Partial convert result is now part of `transformHeader`:
```json
                "header": {
                    "type": "ipv4-acl",
                    "origin": "18d44c85-f83f-4521-91bb-fe5f27ea9a28",
                    "origname": "ACL4-Full-bsn",
                    "subelements": [],
                    "status": "partial",
                    "info": [
                        "sequence[21] contains entry plp = low which cannot be converted",
                        "sequence[21] contains entry class = ade9fe6a-fce1-403a-a63c-fa01a90356a2 which cannot be converted",
                        "sequence[31] contains entry plp = high which cannot be converted",
                        "sequence[41] contains entry plp = low which cannot be converted",
                        "sequence[41] contains entry class = ade9fe6a-fce1-403a-a63c-fa01a90356a2 which cannot be converted",
                        "sequence[41] contains action class = ref=UUID('ade9fe6a-fce1-403a-a63c-fa01a90356a2') which cannot be converted"
                    ]
                },
                "parcel": {
                    "name": "ACL4-Full-bsn",
                    "description": "ACL4-Full-bsn Description",
                    "data": {}
```
# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
