### PR TITLE
Clearing config groups fix

### DIFF
--- a/catalystwan/api/config_group_api.py
+++ b/catalystwan/api/config_group_api.py
@@ -144,4 +144,7 @@ class ConfigGroupAPI:
         """
         config_groups = self.get()
         for config_group in config_groups:
+            if config_group.devices:
+                self.disassociate(str(config_group.id), config_group.devices)
+
             self.delete(config_group.id)


### PR DESCRIPTION
# Pull Request summary:
Clear ux2 function raises an Exception during clearing the config groups with attached devices.
Before an attempt to delete the config group, count of attached devices shall be checked -> if any available then it must be disassociated firstly.


# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
