### PR TITLE
dev-uxmt: no suffix in transform defaults

### DIFF
--- a/catalystwan/utils/config_migration/runner.py
+++ b/catalystwan/utils/config_migration/runner.py
@@ -149,7 +149,7 @@ class ConfigMigrationRunner:
                     f.write(ux1.model_dump_json(exclude_none=True, by_alias=True, indent=4, warnings=False))
 
             # transform to ux2 and dump to json file
-            _transform_result = transform(UX1Config.model_validate_json(open(self.ux1_dump).read()), self.progress)
+            _transform_result = transform(UX1Config.model_validate_json(open(self.ux1_dump).read()), True)
             with open(self.ux2_dump, "w") as f:
                 f.write(_transform_result.model_dump_json(exclude_none=True, by_alias=True, indent=4, warnings=False))
 

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -233,7 +233,7 @@ def get_version_info(session: ManagerSession) -> VersionInfo:
     return VersionInfo(platform=session._platform_version, sdk=PACKAGE_VERSION)
 
 
-def transform(ux1: UX1Config, add_suffix: bool = True) -> ConfigTransformResult:
+def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult:
     transform_result = ConfigTransformResult()
     ux2 = UX2Config(version=ux1.version)
     subtemplates_mapping = defaultdict(set)
@@ -500,6 +500,7 @@ def transform(ux1: UX1Config, add_suffix: bool = True) -> ConfigTransformResult:
     transform_result.ux2_config = ux2
     if add_suffix:
         transform_result.add_suffix_to_names()
+    transform_result.resolve_conflicts_on_policy_object_parcel_names(add_suffix)
     transform_result.ux2_config = UX2Config.model_validate(transform_result.ux2_config)
     return transform_result
 


### PR DESCRIPTION
# Pull Request summary:
remove adding suffix in transform() by default
ConfigMigrationRunner is still providing suffix by default when performing transform

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
