### PR TITLE
dev-uxmt: FT convert guard

### DIFF
--- a/catalystwan/utils/config_migration/converters/feature_template/base.py
+++ b/catalystwan/utils/config_migration/converters/feature_template/base.py
@@ -30,6 +30,6 @@ class FTConverter(ABC):
         try:
             parcel = self.create_parcel(name, description, template_values)
             self._convert_result.output = parcel
-        except CatalystwanConverterCantConvertException as e:
+        except (CatalystwanConverterCantConvertException, AttributeError, LookupError, TypeError, ValueError) as e:
             self._convert_result.update_status("failed", str(e))
         return self._convert_result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.33.8dev1"
+version = "0.33.8dev2"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
Guard FT converters against common exceptions when manipulating collections which are not fully typed

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
