### PR TITLE
dev-uxmt: Converter: as-path

### DIFF
--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -564,7 +564,7 @@ class PolicyConvertContext:
         return vpn_map
 
     def generate_as_path_list_num_from_name(self, name: str) -> int:
-        """The UX1 and UX2 intersection in AS Path list name and ID but only for the vEdge router (number 1 to 500).
+        """The UX1 and UX2 intersection in AS Path list name and ID but only for the ISR Edge router (number 1 to 500).
         If there is number we can insert the value in as_path_list_num field otherwise we will
         generate the value and keep track of it in the context."""
         number = len(self.as_path_list_num_mapping) + 1

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -554,6 +554,7 @@ class PolicyConvertContext:
     zone_based_firewall_residues: Dict[UUID, List[ZoneBasedFWPolicyEntry]] = field(default_factory=dict)
     security_policy_residues: Dict[UUID, SecurityPolicyResidues] = field(default_factory=dict)
     qos_map_residues: Dict[UUID, List[QoSMapResidues]] = field(default_factory=dict)
+    as_path_list_num_mapping: Dict[str, int] = field(default_factory=dict)
 
     def get_vpn_id_to_vpn_name_map(self) -> Dict[Union[str, int], List[str]]:
         vpn_map: Dict[Union[str, int], List[str]] = {}
@@ -561,6 +562,14 @@ class PolicyConvertContext:
             vpn_map[v] = vpn_map.get(v, [])
             vpn_map[v].append(k)
         return vpn_map
+
+    def generate_as_path_list_num_from_name(self, name: str) -> int:
+        """The UX1 and UX2 intersection in AS Path list name and ID but only for the vEdge router (number 1 to 500).
+        If there is number we can insert the value in as_path_list_num field otherwise we will
+        generate the value and keep track of it in the context."""
+        number = len(self.as_path_list_num_mapping) + 1
+        self.as_path_list_num_mapping[name] = number
+        return number
 
     @staticmethod
     def from_configs(

--- a/catalystwan/tests/config_migration/policy_converters/test_aspath.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_aspath.py
@@ -1,0 +1,63 @@
+import unittest
+from uuid import uuid4
+
+from catalystwan.models.configuration.config_migration import PolicyConvertContext
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.policy.as_path import AsPathParcel
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.amp import (
+    AdvancedMalwareProtectionParcel,
+)
+from catalystwan.models.policy.definition.amp import (
+    AdvancedMalwareProtectionDefinition,
+    AdvancedMalwareProtectionPolicy,
+)
+from catalystwan.models.policy.list.as_path import ASPathList, ASPathListEntry
+from catalystwan.utils.config_migration.converters.policy.policy_lists import convert
+
+
+class TestAsPathConverter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context = PolicyConvertContext()
+
+    def test_aspath_with_name_conversion(self):
+        # Arrange
+        name = "aspath"
+        description = "aspath description"
+        entry_1 = "600008"
+        entry_2 = "600009"
+        entry_3 = "600010"
+        aspath = ASPathList(
+            name=name,
+            description=description,
+        )
+        for entry in [entry_1, entry_2, entry_3]:
+            aspath._add_entry(ASPathListEntry(as_path=entry))
+        # Act
+        parcel = convert(aspath, self.context).output
+        # Assert
+        assert isinstance(parcel, AsPathParcel)
+        assert parcel.parcel_name == name
+        assert parcel.parcel_description == description
+        assert len(parcel.entries) == 3
+        assert parcel.entries[0].as_path.value == entry_1
+        assert parcel.entries[1].as_path.value == entry_2
+        assert parcel.entries[2].as_path.value == entry_3
+        assert parcel.as_path_list_num.value == self.context.as_path_list_num_mapping[name]
+
+    def test_aspath_with_number_conversion(self):
+        # Arrange
+        name = "490"
+        description = "aspath description"
+        aspath = ASPathList(
+            name=name,
+            description=description,
+        )
+        # Act
+        parcel = convert(aspath, self.context).output
+        # Assert
+        assert isinstance(parcel, AsPathParcel)
+        assert parcel.parcel_name == name
+        assert parcel.parcel_description == description
+        assert len(parcel.entries) == 0
+        assert parcel.as_path_list_num.value == 490
+
+

--- a/catalystwan/tests/config_migration/policy_converters/test_aspath.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_aspath.py
@@ -1,15 +1,7 @@
 import unittest
-from uuid import uuid4
 
 from catalystwan.models.configuration.config_migration import PolicyConvertContext
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object.policy.as_path import AsPathParcel
-from catalystwan.models.configuration.feature_profile.sdwan.policy_object.security.amp import (
-    AdvancedMalwareProtectionParcel,
-)
-from catalystwan.models.policy.definition.amp import (
-    AdvancedMalwareProtectionDefinition,
-    AdvancedMalwareProtectionPolicy,
-)
 from catalystwan.models.policy.list.as_path import ASPathList, ASPathListEntry
 from catalystwan.utils.config_migration.converters.policy.policy_lists import convert
 
@@ -59,5 +51,3 @@ class TestAsPathConverter(unittest.TestCase):
         assert parcel.parcel_description == description
         assert len(parcel.entries) == 0
         assert parcel.as_path_list_num.value == 490
-
-

--- a/catalystwan/utils/config_migration/converters/policy/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_lists.py
@@ -105,7 +105,7 @@ def as_path(in_: ASPathList, context: PolicyConvertContext) -> ConvertResult[AsP
     - AS Path List ID (Number from 1 to 500)
     - AS Path list
 
-    The UX1 and UX2 intersection in AS Path list name and ID but only for the vEdge router (number 1 to 500).
+    The UX1 and UX2 intersection in AS Path list name and ID but only for the ISR Edge router (number 1 to 500).
     If there is number we can insert the value in as_path_list_num field otherwise we will
     generate the value and keep track of it in the context.
     """


### PR DESCRIPTION
# Pull Request summary:
- add as-path converter
- add unit tests

# Description of changes:
```
There is a mismatch between UX1 and UX2 models:
    UX1:
    - AS Path List Name (Alphanumeric value for vEdge, or number from 1 to 500 for ISR Edge router)
    - AS Path list

    UX2:
    - Parcel name
    - Parcel description
    - AS Path List ID (Number from 1 to 500)
    - AS Path list

    The UX1 and UX2 intersection in AS Path list name and ID but only for the ISR Edge router (number 1 to 500).
    If there is number we can insert the value in as_path_list_num field otherwise we will
    generate the value and keep track of it in the context.
```

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
