### PR TITLE
dev: Fr/policy groups aggregation

### DIFF
--- a/catalystwan/api/policy_api.py
+++ b/catalystwan/api/policy_api.py
@@ -369,9 +369,9 @@ class SecurityPolicyAPI:
         # POST does not return anything! we need to list all after creation and find by name to get id
         self._endpoints.create_security_template(policy)
         policy_infos = [
-            info.root
-            for info in self._endpoints.generate_security_template_list()
-            if info.root.policy_name == policy.policy_name
+            info
+            for info in self._endpoints.generate_security_template_list().root
+            if info.policy_name == policy.policy_name
         ]
         assert len(policy_infos) == 1
         return policy_infos[0].policy_id

--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -279,7 +279,7 @@ class TemplatesAPI:
     def delete(self, template: Type[CLITemplate], name: str) -> bool:  # type: ignore
         ...
 
-    def delete(self, template, name):
+    def delete(self, template, name) -> bool:
         status = False
 
         if template is FeatureTemplate:

--- a/catalystwan/api/templates/device_template/device_template.py
+++ b/catalystwan/api/templates/device_template/device_template.py
@@ -113,6 +113,11 @@ class DeviceTemplate(BaseModel):
         resp = session.get(f"dataservice/template/device/object/{device_template.id}").json()
         return DeviceTemplate(**resp)
 
+    def associate_feature_template(self, template_type: str, template_uuid: UUID) -> None:
+        self.general_templates.append(
+            GeneralTemplate(name="", template_id=str(template_uuid), template_type=template_type)
+        )
+
     model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
 
 

--- a/catalystwan/api/templates/device_template/device_template.py
+++ b/catalystwan/api/templates/device_template/device_template.py
@@ -118,6 +118,12 @@ class DeviceTemplate(BaseModel):
             GeneralTemplate(name="", template_id=str(template_uuid), template_type=template_type)
         )
 
+    def associate_security_policy(self, security_policy_uuid: UUID) -> None:
+        self.security_policy_id = str(security_policy_uuid)
+
+    def associate_policy(self, policy_uuid: UUID) -> None:
+        self.policy_id = str(policy_uuid)
+
     model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
 
 

--- a/catalystwan/endpoints/configuration/policy_group.py
+++ b/catalystwan/endpoints/configuration/policy_group.py
@@ -3,7 +3,7 @@
 # mypy: disable-error-code="empty-body"
 from uuid import UUID
 
-from catalystwan.endpoints import APIEndpoints, delete, get, post, versions
+from catalystwan.endpoints import APIEndpoints, delete, get, post, put, versions
 from catalystwan.models.configuration.policy_group import PolicyGroup, PolicyGroupId, PolicyGroupInfo
 from catalystwan.typed_list import DataSequence
 
@@ -17,6 +17,11 @@ class PolicyGroupEndpoints(APIEndpoints):
     @get("/v1/policy-group")
     @versions(">=20.12")
     def get_all(self) -> DataSequence[PolicyGroupInfo]:
+        ...
+
+    @put("/v1/policy-group/{group_id}")
+    @versions(">=20.12")
+    def update(self, group_id: UUID, payload: PolicyGroup) -> None:
         ...
 
     @delete("/v1/policy-group/{group_id}")

--- a/catalystwan/endpoints/configuration/policy_group.py
+++ b/catalystwan/endpoints/configuration/policy_group.py
@@ -4,7 +4,7 @@
 from uuid import UUID
 
 from catalystwan.endpoints import APIEndpoints, delete, get, post, versions
-from catalystwan.models.configuration.policy_group import PolicyGroup, PolicyGroupId
+from catalystwan.models.configuration.policy_group import PolicyGroup, PolicyGroupId, PolicyGroupInfo
 from catalystwan.typed_list import DataSequence
 
 
@@ -16,7 +16,7 @@ class PolicyGroupEndpoints(APIEndpoints):
 
     @get("/v1/policy-group")
     @versions(">=20.12")
-    def get_all(self) -> DataSequence[PolicyGroupId]:
+    def get_all(self) -> DataSequence[PolicyGroupInfo]:
         ...
 
     @delete("/v1/policy-group/{group_id}")

--- a/catalystwan/integration_tests/test_migration_flow.py
+++ b/catalystwan/integration_tests/test_migration_flow.py
@@ -68,6 +68,9 @@ class TestMigrationFlow(TestCaseBase):
         super().tearDownClass()
 
 
+COPY_DEVICE_TEMPLATE_FROM = "Factory_Default_C8000V_V01"
+
+
 class TestPolicyGroupAggregation(TestCaseBase):
     runner: ConfigMigrationRunner
     sig_name: str
@@ -125,11 +128,11 @@ class TestPolicyGroupAggregation(TestCaseBase):
         assert len([fp for fp in feature_profiles if fp.profile_name.startswith(self.sig_name)]) == 1
         assert len([fp for fp in feature_profiles if fp.profile_name.startswith(self.localized_policy_name)]) == 1
         assert len([fp for fp in feature_profiles if fp.profile_name.startswith(self.security_policy_name)]) == 1
-        assert len([fp for fp in feature_profiles if fp.profile_name.startswith(self.security_policy_name)]) == 1
+        assert len([fp for fp in feature_profiles if fp.profile_name.startswith(self.dns_security_name)]) == 1
 
     def _create_device_template(self) -> None:
         templates = self.session.api.templates
-        dt = DeviceTemplate.get("Factory_Default_C8000V_V01", self.session)
+        dt = DeviceTemplate.get(COPY_DEVICE_TEMPLATE_FROM, self.session)
         dt.template_name = self.device_template_name
         dt.factory_default = False
         dt.associate_feature_template(CiscoSecureInternetGatewayModel.type, UUID(self.sig_uuid))
@@ -264,6 +267,7 @@ class TestPolicyGroupAggregation(TestCaseBase):
         self.pol_dict["AdvancedInspectionProfilePolicy"] = api.definitions.create(aip)
         zbfwp = ZoneBasedFWPolicy(name=create_name_with_run_id("ZoneBasedFWPolicy"))
         zbfwp.mode = "unified"
+        zbfwp.add_zone_pair("self", "default")
         zbfwp_seq = zbfwp.add_ipv4_rule(name=create_name_with_run_id("IPv4Rule"), base_action="inspect")
         zbfwp_seq.set_advanced_inspection_profile_action(profile_id=self.pol_dict["AdvancedInspectionProfilePolicy"])
         zbfwp_seq.match_source_port(ports=set([34000, 34568]))

--- a/catalystwan/integration_tests/test_migration_flow.py
+++ b/catalystwan/integration_tests/test_migration_flow.py
@@ -1,7 +1,19 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 
 
-from catalystwan.integration_tests.base import TestCaseBase
+from ipaddress import IPv4Address, IPv4Interface
+from uuid import UUID
+
+from catalystwan.api.templates.device_template.device_template import DeviceTemplate
+from catalystwan.api.templates.feature_template import FeatureTemplate
+from catalystwan.api.templates.models.cisco_secure_internet_gateway import (
+    CiscoSecureInternetGatewayModel,
+    Interface,
+    InterfacePair,
+    Service,
+    Tracker,
+)
+from catalystwan.integration_tests.base import TestCaseBase, create_name_with_run_id
 from catalystwan.utils.config_migration.runner import ConfigMigrationRunner
 
 
@@ -36,3 +48,149 @@ class TestMigrationFlow(TestCaseBase):
     def tearDownClass(cls) -> None:
         cls.runner.clear_ux2()
         super().tearDownClass()
+
+
+class TestPolicyGroupAggregation(TestCaseBase):
+    runner: ConfigMigrationRunner
+    sig_name: str
+    sig_uuid: str
+    device_template_name: str
+    device_template_uuid: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # --------------------------------------
+        # Create SIG Feature Template
+        # --------------------------------------
+        templates = cls.session.api.templates
+        cls.sig_name = create_name_with_run_id("SIG")
+        cisco_sig = CiscoSecureInternetGatewayModel(
+            template_name=cls.sig_name,
+            template_description="Comprehensive CiscoSecureInternetGateway Configuration",
+            vpn_id=10,
+            child_org_id="example_org",
+            interface=[
+                Interface(
+                    if_name="GigabitEthernet0/0",
+                    auto=True,
+                    shutdown=False,
+                    description="Main interface for SIG",
+                    unnumbered=False,
+                    address=IPv4Interface("192.168.1.1/24"),
+                    tunnel_source=IPv4Address("192.168.1.1"),
+                    tunnel_source_interface="Loopback0",
+                    tunnel_route_via="192.168.2.1",
+                    tunnel_destination="203.0.113.1",
+                    application="sig",
+                    tunnel_set="secure-internet-gateway-umbrella",
+                    tunnel_dc_preference="primary-dc",
+                    tcp_mss_adjust=1400,
+                    mtu=1400,
+                    dpd_interval=30,
+                    dpd_retries=3,
+                    ike_version=2,
+                    pre_shared_secret="MyPreSharedSecret",  # pragma: allowlist secret
+                    ike_rekey_interval=3600,
+                    ike_ciphersuite="aes256-cbc-sha1",
+                    ike_group="14",
+                    pre_shared_key_dynamic=False,
+                    ike_local_id="local-id",
+                    ike_remote_id="remote-id",
+                    ipsec_rekey_interval=3600,
+                    ipsec_replay_window=32,
+                    ipsec_ciphersuite="aes256-gcm",
+                    perfect_forward_secrecy="group-14",
+                    tracker=True,
+                    track_enable=True,
+                )
+            ],
+            service=[
+                Service(
+                    svc_type="sig",
+                    interface_pair=[
+                        InterfacePair(
+                            active_interface="GigabitEthernet0/0",
+                            active_interface_weight=10,
+                            backup_interface="GigabitEthernet0/1",
+                            backup_interface_weight=5,
+                        )
+                    ],
+                    auth_required=True,
+                    xff_forward_enabled=True,
+                    ofw_enabled=False,
+                    ips_control=True,
+                    caution_enabled=False,
+                    primary_data_center="Auto",
+                    secondary_data_center="Auto",
+                    ip=True,
+                    idle_time=30,
+                    display_time_unit="MINUTE",
+                    ip_enforced_for_known_browsers=True,
+                    refresh_time=5,
+                    refresh_time_unit="MINUTE",
+                    enabled=True,
+                    block_internet_until_accepted=False,
+                    force_ssl_inspection=True,
+                    timeout=60,
+                    data_center_primary="Auto",
+                    data_center_secondary="Auto",
+                )
+            ],
+            tracker_src_ip=IPv4Interface("192.0.2.1/32"),
+            tracker=[
+                Tracker(
+                    name="health-check-tracker",
+                    endpoint_api_url="https://api.example.com/health",
+                    threshold=5,
+                    interval=60,
+                    multiplier=2,
+                    tracker_type="SIG",
+                )
+            ],
+        )
+        cls.sig_uuid = templates.create(cisco_sig)
+        # --------------------------------------
+        # Create Device Template
+        # --------------------------------------
+        dt = DeviceTemplate.get(
+            "Factory_Default_C8000V_V01",
+            cls.session,
+        )
+        cls.device_template_name = create_name_with_run_id("DeviceTemplate_to_PolicyGroup")
+        dt.template_name = cls.device_template_name
+        dt.factory_default = False
+        dt.associate_feature_template(cisco_sig.type, UUID(cls.sig_uuid))
+        cls.device_template_uuid = templates.create(dt)
+        # --------------------------------------
+        # Run Migration
+        # --------------------------------------
+        cls.runner = ConfigMigrationRunner.collect_and_push(cls.session, filter=cls.device_template_name)
+        cls.runner.set_dump_prefix("aggregation")
+        cls.runner.run()
+
+    def test_sss(self):
+        """Test Policy Group Aggregation
+
+        When:
+        UX1.0: Device Template has associated a SIG Feature Template, Security Policy and Localized Policy
+
+        Expect:
+        UX2.0: Policy Group with associated SIG, Application Priority & SLA, Security, DNS Security Feature Profiles
+        """
+        # Act
+        policy_group = (
+            self.session.endpoints.configuration.policy_group.get_all()
+            .filter(name=self.device_template_name)
+            .single_or_default()
+        )
+        # Assert
+        assert policy_group is not None
+        assert policy_group.get_profile_by_name(self.sig_name) is not None
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.session.api.templates.delete(DeviceTemplate, cls.device_template_name)
+        cls.session.api.templates.delete(FeatureTemplate, cls.sig_name)  # type: ignore
+        cls.runner.clear_ux2()
+        return super().tearDownClass()

--- a/catalystwan/integration_tests/test_migration_flow.py
+++ b/catalystwan/integration_tests/test_migration_flow.py
@@ -167,6 +167,10 @@ class TestPolicyGroupAggregation(TestCaseBase):
         # --------------------------------------
         cls.runner = ConfigMigrationRunner.collect_and_push(cls.session, filter=cls.device_template_name)
         cls.runner.set_dump_prefix("aggregation")
+        cls.runner.set_filters(
+            device_template_name=cls.device_template_name,
+            feature_template_name=cls.sig_name,
+        )
         cls.runner.run()
 
     def test_sss(self):

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -500,7 +500,7 @@ class UX2ConfigPushReport(BaseModel):
         self.standalone_feature_profiles.extend(feature_profiles)
 
     def get_standalone_feature_profiles_by_ids(self, uuids: Set[UUID]) -> List[FeatureProfileBuildReport]:
-        return [f for f in self.standalone_feature_profiles if f.profile_uuid in uuids]
+        return [f for f in self.standalone_feature_profiles + self.security_policies if f.profile_uuid in uuids]
 
     def set_failed_push_parcels_flat_list(self):
         for group in self.groups:

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -423,7 +423,10 @@ class ConfigTransformResult(BaseModel):
         )
         self.unsupported_items.append(item)
 
+
 GroupTypes = Literal["config", "topology", "policy", "base"]
+
+
 class GroupReportBase(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid", alias_generator=camel)
     type_: GroupTypes = Field(default="base", exclude=True)

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -666,6 +666,7 @@ class PolicyConvertContext:
         return context
 
     def populate_activated_centralized_policy_item_ids(self, centralized_policies: List[CentralizedPolicyInfo]) -> None:
+        """For Cflowd - only convert and push the active policy"""
         active_policy = next((policy for policy in centralized_policies if policy.is_policy_activated), None)
         if active_policy is None or isinstance(active_policy.policy_definition, str):
             return

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -680,6 +680,7 @@ class PushContext:
     id_lookup: Dict[UUID, UUID] = field(
         default_factory=dict
     )  # universal lookup for finding pushed item id by origin id
+    policy_group_feature_profiles_id_lookup: Dict[UUID, UUID] = field(default_factory=dict)
 
 
 @dataclass

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -14,7 +14,7 @@ from catalystwan.api.builders.feature_profiles.report import (
     FailedRequestDetails,
     FeatureProfileBuildReport,
 )
-from catalystwan.api.templates.device_template.device_template import DeviceTemplate, GeneralTemplate
+from catalystwan.api.templates.device_template.device_template import DeviceTemplate, GeneralTemplate, str_to_uuid
 from catalystwan.endpoints.configuration_group import ConfigGroupCreationPayload
 from catalystwan.endpoints.configuration_settings import CloudCredentials
 from catalystwan.exceptions import ManagerHTTPError
@@ -25,6 +25,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.policy_object import
 from catalystwan.models.configuration.feature_profile.sdwan.service.lan.vpn import LanVpnParcel
 from catalystwan.models.configuration.network_hierarchy.cflowd import CflowdParcel
 from catalystwan.models.configuration.network_hierarchy.node import NodeInfo
+from catalystwan.models.configuration.policy_group import PolicyGroup
 from catalystwan.models.configuration.topology_group import TopologyGroup
 from catalystwan.models.policy import AnyPolicyDefinitionInfo, AnyPolicyListInfo, URLAllowListInfo, URLBlockListInfo
 from catalystwan.models.policy.centralized import CentralizedPolicyInfo
@@ -82,6 +83,22 @@ class DeviceTemplateWithInfo(DeviceTemplate):
             **info_dict,
         )
 
+    def get_sig_template_uuid(self) -> Optional[UUID]:
+        """SIG template is part of a PolicyGroup in UX2.0"""
+
+        def __traverse_general_templates(general_templates: List[GeneralTemplate]) -> Optional[UUID]:
+            """Traverse the general templates to find the SIG template uuid"""
+            for general_template in general_templates:
+                if general_template.template_type == "cisco_secure_internet_gateway":
+                    return general_template.template_id
+                if general_template.sub_templates:
+                    if result := __traverse_general_templates(general_template.sub_templates):
+                        return result
+            return None
+
+        result = __traverse_general_templates(self.general_templates)
+        return str_to_uuid(result) if result else None
+
     def get_flattened_general_templates(self) -> List[GeneralTemplate]:
         """
         Flatten the representation but leave cisco vpn templates and
@@ -111,6 +128,15 @@ class UX1Policies(BaseModel):
     security_policies: List[AnySecurityPolicyInfo] = Field(default_factory=list)
     policy_definitions: List[AnyPolicyDefinitionInfo] = Field(default_factory=list)
     policy_lists: List[AnyPolicyListInfo] = Field(default_factory=list)
+
+    def get_centralized_policy_by_id(self, policy_id: UUID) -> Optional[CentralizedPolicyInfo]:
+        return next((p for p in self.centralized_policies if p.policy_id == policy_id), None)
+
+    def get_localized_policy_by_id(self, policy_id: UUID) -> Optional[LocalizedPolicyInfo]:
+        return next((p for p in self.localized_policies if p.policy_id == policy_id), None)
+
+    def get_security_policy_by_id(self, policy_id: UUID) -> Optional[AnySecurityPolicyInfo]:
+        return next((p for p in self.security_policies if p.policy_id == policy_id), None)
 
 
 class UX1Templates(BaseModel):
@@ -180,6 +206,12 @@ class TransformedConfigGroup(BaseModel):
     config_group: ConfigGroupCreationPayload
 
 
+class TransformedPolicyGroup(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=camel)
+    header: TransformHeader
+    policy_group: PolicyGroup
+
+
 class TransformedFeatureProfile(BaseModel):
     model_config = ConfigDict(populate_by_name=True, alias_generator=camel)
     header: TransformHeader
@@ -220,7 +252,7 @@ class UX2Config(BaseModel):
     version: VersionInfo = VersionInfo()
     topology_groups: List[TransformedTopologyGroup] = Field(default_factory=list)
     config_groups: List[TransformedConfigGroup] = Field(default_factory=list)
-    policy_groups: List[TransformedConfigGroup] = Field(default_factory=list)
+    policy_groups: List[TransformedPolicyGroup] = Field(default_factory=list)
     feature_profiles: List[TransformedFeatureProfile] = Field(default_factory=list)
     profile_parcels: List[TransformedParcel] = Field(default_factory=list)
     cloud_credentials: Optional[CloudCredentials] = Field(default=None)

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -492,9 +492,15 @@ class UX2ConfigPushReport(BaseModel):
     def add_report(self, name: str, uuid: UUID, feature_profiles: List[FeatureProfileBuildReport]) -> None:
         self.config_groups.append(ConfigGroupReport(name=name, uuid=uuid, feature_profiles=feature_profiles))
 
+    def add_pg_report(self, name: str, uuid: UUID, feature_profiles: List[FeatureProfileBuildReport]) -> None:
+        self.policy_groups.append(PolicyGroupReport(name=name, uuid=uuid, feature_profiles=feature_profiles))
+
     def add_standalone_feature_profiles(self, feature_profiles: List[FeatureProfileBuildReport]) -> None:
         """This happends when parent config group failes to create or profile don't have config group"""
         self.standalone_feature_profiles.extend(feature_profiles)
+
+    def get_standalone_feature_profiles_by_ids(self, uuids: Set[UUID]) -> List[FeatureProfileBuildReport]:
+        return [f for f in self.standalone_feature_profiles if f.profile_uuid in uuids]
 
     def set_failed_push_parcels_flat_list(self):
         for group in self.groups:

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -86,7 +86,7 @@ class DeviceTemplateWithInfo(DeviceTemplate):
     def get_sig_template_uuid(self) -> Optional[UUID]:
         """SIG template is part of a PolicyGroup in UX2.0"""
 
-        def __traverse_general_templates(general_templates: List[GeneralTemplate]) -> Optional[UUID]:
+        def __traverse_general_templates(general_templates: List[GeneralTemplate]) -> Optional[str]:
             """Traverse the general templates to find the SIG template uuid"""
             for general_template in general_templates:
                 if general_template.template_type == "cisco_secure_internet_gateway":

--- a/catalystwan/models/configuration/policy_group.py
+++ b/catalystwan/models/configuration/policy_group.py
@@ -33,6 +33,11 @@ class PolicyGroup(BaseModel):
     )
     solution: Optional[Solution] = Field(default=None)
 
+    def add_profile(self, profile_uuid: UUID) -> None:
+        if self.profiles is None:
+            self.profiles = []
+        self.profiles.append(Profile(id=profile_uuid))
+
 
 class ProfileInfo(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -46,7 +51,6 @@ class ProfileInfo(BaseModel):
 class PolicyGroupId(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     id: UUID
-    name: str
     profiles: Optional[List[ProfileInfo]] = Field(
         default=None,
         description="(Optional - only applicable for AON) List of profile ids that belongs to the policy group",
@@ -60,3 +64,7 @@ class PolicyGroupId(BaseModel):
             if profile.name == name:
                 return profile
         return None
+
+
+class PolicyGroupInfo(PolicyGroupId):
+    name: str

--- a/catalystwan/models/configuration/policy_group.py
+++ b/catalystwan/models/configuration/policy_group.py
@@ -40,12 +40,23 @@ class ProfileInfo(BaseModel):
     profile_type: Optional[Literal["global"]] = Field(
         default=None, validation_alias="profileType", serialization_alias="profileType"
     )
+    name: str
 
 
 class PolicyGroupId(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     id: UUID
+    name: str
     profiles: Optional[List[ProfileInfo]] = Field(
         default=None,
         description="(Optional - only applicable for AON) List of profile ids that belongs to the policy group",
     )
+
+    def get_profile_by_name(self, name: str) -> Optional[ProfileInfo]:
+        if self.profiles is None:
+            return None
+
+        for profile in self.profiles:
+            if profile.name == name:
+                return profile
+        return None

--- a/catalystwan/models/configuration/policy_group.py
+++ b/catalystwan/models/configuration/policy_group.py
@@ -20,6 +20,9 @@ class FromPolicyGroup(BaseModel):
 
 
 class PolicyGroup(BaseModel):
+    """Payload for creating a policy group.
+    Policy Object Profile is required to create a policy group."""
+
     model_config = ConfigDict(populate_by_name=True)
     description: str = Field(
         description="description of the policy group. Max length is ulimited. (>500 000 for 20.12)"

--- a/catalystwan/models/configuration/policy_group.py
+++ b/catalystwan/models/configuration/policy_group.py
@@ -21,8 +21,10 @@ class FromPolicyGroup(BaseModel):
 
 class PolicyGroup(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    description: str = Field()
-    name: str = Field(pattern='^[^&<>! "]+$')
+    description: str = Field(
+        description="description of the policy group. Max length is ulimited. (>500 000 for 20.12)"
+    )
+    name: str = Field(pattern='^[^&<>! "]+$', max_length=128)
     from_policy_group: Optional[FromPolicyGroup] = Field(
         default=None, validation_alias="fromPolicyGroup", serialization_alias="fromPolicyGroup"
     )

--- a/catalystwan/models/policy/list/local_domain.py
+++ b/catalystwan/models/policy/list/local_domain.py
@@ -24,6 +24,9 @@ class LocalDomainList(PolicyListBase):
     type: Literal["localDomain"] = "localDomain"
     entries: List[LocalDomainListEntry] = []
 
+    def add_domain(self, name_server: str) -> None:
+        self.entries.append(LocalDomainListEntry(name_server=name_server))
+
 
 class LocalDomainListEditPayload(LocalDomainList, PolicyListId):
     pass

--- a/catalystwan/models/policy/policy_definition.py
+++ b/catalystwan/models/policy/policy_definition.py
@@ -117,6 +117,11 @@ class Reference(BaseModel):
     ref: UUID
 
 
+class ReferenceWithId(BaseModel):
+    field: Literal["id"] = "id"
+    ref: UUID
+
+
 class ReferenceList(BaseModel):
     ref: SpaceSeparatedUUIDList
 
@@ -858,7 +863,7 @@ class ConnectionEventsAction(BaseModel):
 
 class AdvancedInspectionProfileAction(BaseModel):
     type: Literal["advancedInspectionProfile"] = "advancedInspectionProfile"
-    parameter: Reference
+    parameter: ReferenceWithId
 
 
 ActionSetEntry = Annotated[

--- a/catalystwan/models/policy/security.py
+++ b/catalystwan/models/policy/security.py
@@ -168,9 +168,13 @@ class SecurityPolicy(PolicyCreationPayload):
 
 
 class UnifiedSecurityPolicy(PolicyCreationPayload):
-    policy_mode: Literal["unified"] = Field("unified", serialization_alias="policyMode", validation_alias="policyMode")
-    policy_type: str = Field("feature", serialization_alias="policyType", validation_alias="policyType")
-    policy_use_case: str = Field("custom", serialization_alias="policyUseCase", validation_alias="policyUseCase")
+    policy_mode: Literal["unified"] = Field(
+        default="unified", serialization_alias="policyMode", validation_alias="policyMode"
+    )
+    policy_type: str = Field(default="feature", serialization_alias="policyType", validation_alias="policyType")
+    policy_use_case: str = Field(
+        default="custom", serialization_alias="policyUseCase", validation_alias="policyUseCase"
+    )
     policy_definition: UnifiedSecurityPolicyDefinition = Field(
         default=UnifiedSecurityPolicyDefinition(),
         serialization_alias="policyDefinition",

--- a/catalystwan/models/policy/security.py
+++ b/catalystwan/models/policy/security.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Set, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress, RootModel, field_validator
@@ -135,6 +135,9 @@ class SecurityPolicy(PolicyCreationPayload):
         default=SecurityPolicyDefinition(), serialization_alias="policyDefinition", validation_alias="policyDefinition"
     )
 
+    def get_assemby_item_uuids(self) -> Set[UUID]:
+        return set((item.definition_id for item in self.policy_definition.assembly))
+
     def add_item(self, item: SecurityPolicyAssemblyItem) -> None:
         self.policy_definition.assembly.append(item)
 
@@ -173,6 +176,9 @@ class UnifiedSecurityPolicy(PolicyCreationPayload):
         serialization_alias="policyDefinition",
         validation_alias="policyDefinition",
     )
+
+    def get_assemby_item_uuids(self) -> Set[UUID]:
+        return set((item.definition_id for item in self.policy_definition.assembly))
 
     def add_item(self, item: UnifiedSecurityPolicyAssemblyItem) -> None:
         self.policy_definition.assembly.append(item)

--- a/catalystwan/tests/config_migration/policy_converters/test_zone_based_firewall_converter.py
+++ b/catalystwan/tests/config_migration/policy_converters/test_zone_based_firewall_converter.py
@@ -50,7 +50,7 @@ from catalystwan.models.policy.policy_definition import (
     ProtocolEntry,
     ProtocolNameEntry,
     ProtocolNameListEntry,
-    Reference,
+    ReferenceWithId,
     RuleSetListEntry,
     SourceDataPrefixListEntry,
     SourceGeoLocationEntry,
@@ -277,7 +277,7 @@ class TestSequenceActionsConverters(unittest.TestCase):
         in_actions = [
             LogAction(),
             ConnectionEventsAction(),
-            AdvancedInspectionProfileAction(parameter=Reference(ref=uuid4())),
+            AdvancedInspectionProfileAction(parameter=ReferenceWithId(ref=uuid4())),
         ]
 
         out = convert_sequence_actions(in_actions, self._convert_result)

--- a/catalystwan/tests/config_migration/test_data/__init__.py
+++ b/catalystwan/tests/config_migration/test_data/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 from typing import List
 
+from .device_template import create_device_template
 from .feature_templates.dhcp import dhcp_server
 from .feature_templates.interface import interface_ethernet, interface_gre, interface_ipsec, interface_multilink
 from .feature_templates.ospfv3 import ospfv3
@@ -20,6 +21,7 @@ __all__ = [
     "interface_multilink",
     "create_qos_map_policy",
     "create_localized_policy_info",
+    "create_device_template",
 ]
 
 

--- a/catalystwan/tests/config_migration/test_data/device_template.py
+++ b/catalystwan/tests/config_migration/test_data/device_template.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+
+from catalystwan.models.configuration.config_migration import DeviceTemplateWithInfo
+
+
+def create_device_template(name) -> DeviceTemplateWithInfo:
+    return DeviceTemplateWithInfo(
+        template_id=str(uuid4()),
+        factory_default=False,
+        devices_attached=0,
+        template_name=name,
+        template_description="Description",
+        device_role="None",
+        device_type="None",
+        security_policy_id="None",
+        policy_id="None",
+    )

--- a/catalystwan/tests/config_migration/test_data/device_template.py
+++ b/catalystwan/tests/config_migration/test_data/device_template.py
@@ -1,10 +1,14 @@
-from uuid import uuid4
+from typing import Optional
+from uuid import UUID, uuid4
 
+from catalystwan.api.templates.device_template.device_template import GeneralTemplate
 from catalystwan.models.configuration.config_migration import DeviceTemplateWithInfo
 
 
-def create_device_template(name) -> DeviceTemplateWithInfo:
-    return DeviceTemplateWithInfo(
+def create_device_template(
+    name, *, sig_uuid: Optional[UUID] = None, security_policy_uuid: Optional[UUID] = None
+) -> DeviceTemplateWithInfo:
+    dt = DeviceTemplateWithInfo(
         template_id=str(uuid4()),
         factory_default=False,
         devices_attached=0,
@@ -15,3 +19,17 @@ def create_device_template(name) -> DeviceTemplateWithInfo:
         security_policy_id="None",
         policy_id="None",
     )
+    if sig_uuid:
+        dt.general_templates = [
+            GeneralTemplate(
+                template_id=str(uuid4()),
+                template_type="cisco_vpn",
+                sub_templates=[
+                    GeneralTemplate(template_id=str(sig_uuid), template_type="cisco_secure_internet_gateway")
+                ],
+            )
+        ]
+    if security_policy_uuid:
+        dt.security_policy_id = str(security_policy_uuid)
+
+    return dt

--- a/catalystwan/tests/config_migration/test_data/device_template.py
+++ b/catalystwan/tests/config_migration/test_data/device_template.py
@@ -6,7 +6,11 @@ from catalystwan.models.configuration.config_migration import DeviceTemplateWith
 
 
 def create_device_template(
-    name, *, sig_uuid: Optional[UUID] = None, security_policy_uuid: Optional[UUID] = None
+    name,
+    *,
+    sig_uuid: Optional[UUID] = None,
+    security_policy_uuid: Optional[UUID] = None,
+    localized_policy_uuid: Optional[UUID] = None
 ) -> DeviceTemplateWithInfo:
     dt = DeviceTemplateWithInfo(
         template_id=str(uuid4()),
@@ -31,5 +35,7 @@ def create_device_template(
         ]
     if security_policy_uuid:
         dt.security_policy_id = str(security_policy_uuid)
+    if localized_policy_uuid:
+        dt.policy_id = str(localized_policy_uuid)
 
     return dt

--- a/catalystwan/tests/config_migration/test_data/security_policy.py
+++ b/catalystwan/tests/config_migration/test_data/security_policy.py
@@ -1,0 +1,12 @@
+from uuid import uuid4
+
+from catalystwan.models.policy.security import SecurityPolicy
+
+
+def create_security_policy(name) -> SecurityPolicy:
+    return SecurityPolicy(
+        policy_id=uuid4(),
+        policy_name=name,
+        policy_description="Description",
+        policy_type="feature",
+    )

--- a/catalystwan/tests/config_migration/test_data/security_policy.py
+++ b/catalystwan/tests/config_migration/test_data/security_policy.py
@@ -1,12 +1,27 @@
+from datetime import datetime
 from uuid import uuid4
 
-from catalystwan.models.policy.security import SecurityPolicy
+from catalystwan.models.policy.policy import DNSSecurityAssemblyItem, ZoneBasedFWAssemblyItem
+from catalystwan.models.policy.security import SecurityPolicyDefinition, SecurityPolicyInfo
 
 
-def create_security_policy(name) -> SecurityPolicy:
-    return SecurityPolicy(
+def create_security_policy(name) -> SecurityPolicyInfo:
+    dns_uuid = uuid4()
+    zbfw_uuid = uuid4()
+
+    return SecurityPolicyInfo(
         policy_id=uuid4(),
         policy_name=name,
+        policy_version="",
         policy_description="Description",
         policy_type="feature",
+        created_by="tester",
+        created_on=datetime.now(),
+        last_updated_by="tester",
+        last_updated_on=datetime.now(),
+        policy_definition=SecurityPolicyDefinition(
+            assembly=[DNSSecurityAssemblyItem(definition_id=dns_uuid), ZoneBasedFWAssemblyItem(definition_id=zbfw_uuid)]
+        ),
+        virtual_application_templates=[],
+        supported_devices=[],
     )

--- a/catalystwan/tests/config_migration/test_data/security_policy.py
+++ b/catalystwan/tests/config_migration/test_data/security_policy.py
@@ -1,15 +1,14 @@
 from datetime import datetime
-from uuid import uuid4
+from typing import Optional
+from uuid import UUID, uuid4
 
-from catalystwan.models.policy.policy import DNSSecurityAssemblyItem, ZoneBasedFWAssemblyItem
-from catalystwan.models.policy.security import SecurityPolicyDefinition, SecurityPolicyInfo
+from catalystwan.models.policy.security import SecurityPolicyInfo
 
 
-def create_security_policy(name) -> SecurityPolicyInfo:
-    dns_uuid = uuid4()
-    zbfw_uuid = uuid4()
-
-    return SecurityPolicyInfo(
+def create_security_policy(
+    name, *, dns_uuid: Optional[UUID] = None, zbfw_uuid: Optional[UUID] = None
+) -> SecurityPolicyInfo:
+    spi = SecurityPolicyInfo(
         policy_id=uuid4(),
         policy_name=name,
         policy_version="",
@@ -19,9 +18,11 @@ def create_security_policy(name) -> SecurityPolicyInfo:
         created_on=datetime.now(),
         last_updated_by="tester",
         last_updated_on=datetime.now(),
-        policy_definition=SecurityPolicyDefinition(
-            assembly=[DNSSecurityAssemblyItem(definition_id=dns_uuid), ZoneBasedFWAssemblyItem(definition_id=zbfw_uuid)]
-        ),
         virtual_application_templates=[],
         supported_devices=[],
     )
+    if dns_uuid:
+        spi.add_dns_security(definition_id=dns_uuid)
+    if zbfw_uuid:
+        spi.add_zone_based_fw(definition_id=zbfw_uuid)
+    return spi

--- a/catalystwan/tests/config_migration/test_device_template_with_info.py
+++ b/catalystwan/tests/config_migration/test_device_template_with_info.py
@@ -1,4 +1,5 @@
 import unittest
+from uuid import uuid4
 
 from catalystwan.api.templates.device_template.device_template import GeneralTemplate
 from catalystwan.models.configuration.config_migration import DeviceTemplateWithInfo
@@ -6,6 +7,9 @@ from catalystwan.models.configuration.config_migration import DeviceTemplateWith
 
 class TestDeviceTemplate(unittest.TestCase):
     def setUp(self):
+        self.sig_uuid = (
+            uuid4()
+        )  # We need to generate a UUID for the SIG template to test the get_sig_template_uuid method
         self.device_template = DeviceTemplateWithInfo(
             template_id="1",
             factory_default=False,
@@ -51,6 +55,12 @@ class TestDeviceTemplate(unittest.TestCase):
                             template_type="cedge_multicast",
                             sub_templates=[],
                         ),
+                        GeneralTemplate(
+                            name="2level - SIG Temaplte",
+                            template_id=str(self.sig_uuid),
+                            template_type="cisco_secure_internet_gateway",
+                            sub_templates=[],
+                        ),
                     ],
                 ),
             ],
@@ -86,7 +96,24 @@ class TestDeviceTemplate(unittest.TestCase):
                             template_type="cedge_multicast",
                             sub_templates=[],
                         ),
+                        GeneralTemplate(
+                            name="2level - SIG Temaplte",
+                            template_id=str(self.sig_uuid),
+                            template_type="cisco_secure_internet_gateway",
+                            sub_templates=[],
+                        ),
                     ],
                 ),
             ],
         )
+
+    def test_when_sig_template_is_assigned_expect_correct_uuid(self):
+        # Act, Assert
+        self.assertEqual(self.device_template.get_sig_template_uuid(), self.sig_uuid)
+
+    def test_when_sig_template_is_not_assigned_expect_correct_none(self):
+        # Arrange
+        self.device_template.general_templates[2].sub_templates = []
+
+        # Act, Assert
+        self.assertIsNone(self.device_template.get_sig_template_uuid())

--- a/catalystwan/tests/config_migration/test_transform.py
+++ b/catalystwan/tests/config_migration/test_transform.py
@@ -633,3 +633,15 @@ def test_policy_profile_merge():
     assert merged_A_B is not None
     assert merged_C_D is not None
     assert separate_E is not None
+
+
+def test_when_no_data_to_push_in_policy_groups_expect_no_policy_groups():
+    """When there is no data to push, there should be no policy groups."""
+    # Arrange
+    ux1 = UX1Config()
+    dt = create_device_template("DT-A")
+    ux1.templates.device_templates = [dt]
+    # Act
+    config = transform(ux1=ux1).ux2_config
+    # Assert
+    assert len(config.policy_groups) == 0

--- a/catalystwan/tests/config_migration/test_transform.py
+++ b/catalystwan/tests/config_migration/test_transform.py
@@ -26,6 +26,8 @@ from catalystwan.tests.config_migration.test_data import (
     vpn_service,
     vpn_transport,
 )
+from catalystwan.tests.config_migration.test_data.device_template import create_device_template
+from catalystwan.tests.config_migration.test_data.security_policy import create_security_policy
 from catalystwan.workflows.config_migration import transform
 
 T = TypeVar("T", FeatureTemplateInformation, _ParcelBase)
@@ -565,3 +567,34 @@ def test_when_localized_policy_with_qos_expect_application_priority_feature_prof
     assert qos_map_2_parcel is not None
     # Settings should be in the list of parcels
     assert settings is not None
+
+
+def test_policy_profile_merge():
+    """Assumptions:
+
+    - dt_a uses sp_1 and sig_1
+    - dt_b uses sp_1 and sig_1
+    - dt_c uses sp_2 and sig_1
+    - dt_d uses sp_2 and sig_1
+    - dt_e uses sp_3
+
+    Expected result:
+    - dt_a, dt_b are merged to one policy group
+    - dt_c, dt_d are merged to another policy group
+    - dt_e is a separate policy group
+
+    """
+    ux1 = UX1Config()
+
+    sig_1_uuid = uuid4()
+
+    dt_A = create_device_template("DT-A")
+    dt_B = create_device_template("DT-B")
+    dt_C = create_device_template("DT-C")
+    dt_D = create_device_template("DT-D")
+    dt_E = create_device_template("DT-E")
+
+    sp_1 = create_security_policy("SP-1")
+    sp_2 = create_security_policy("SP-2")
+
+    dt_A.security_policy_id = sp_1

--- a/catalystwan/tests/config_migration/test_transform.py
+++ b/catalystwan/tests/config_migration/test_transform.py
@@ -577,15 +577,14 @@ def test_when_localized_policy_with_qos_expect_application_priority_feature_prof
 
 
 def test_policy_profile_merge():
-    """Assumptions:
-
+    """When:
     - dt_a uses sp_1, lp_1, sig_1,
     - dt_b uses sp_1, lp_1, sig_1
     - dt_c uses sp_2, lp_2, sig_1
     - dt_d uses sp_2, lp_2, sig_1
     - dt_e uses sp_3, lp_2
 
-    Expected result:
+    Expect:
     - dt_a, dt_b are merged to one policy group
     - dt_c, dt_d are merged to another policy group
     - dt_e is a separate policy group
@@ -595,8 +594,12 @@ def test_policy_profile_merge():
 
     sig_1_uuid = uuid4()
 
-    sp_1 = create_security_policy("SP-1")
-    sp_2 = create_security_policy("SP-2")
+    dns_uuid_1 = uuid4()
+    zbfw_uuid_1 = uuid4()
+    dns_uuid_2 = uuid4()
+    zbfw_uuid_2 = uuid4()
+    sp_1 = create_security_policy("SP-1", dns_uuid=dns_uuid_1, zbfw_uuid=zbfw_uuid_1)
+    sp_2 = create_security_policy("SP-2", dns_uuid=dns_uuid_2, zbfw_uuid=zbfw_uuid_2)
     sp_3 = create_security_policy("SP-3")
 
     lp_1 = create_localized_policy_info("LP-1")
@@ -620,9 +623,9 @@ def test_policy_profile_merge():
     ux1.policies.security_policies = [sp_1, sp_2, sp_3]
     ux1.policies.localized_policies = [lp_1, lp_2]
 
-    merged_A_B_subelements = set().union(sp_1.get_assemby_item_uuids(), {sig_1_uuid}, {lp_1.policy_id})
-    merged_C_D_subelements = set().union(sp_2.get_assemby_item_uuids(), {sig_1_uuid}, {lp_2.policy_id})
-    separate_E_subelements = set().union(sp_3.get_assemby_item_uuids(), {lp_2.policy_id})
+    merged_A_B_subelements = {sp_1.policy_id, dns_uuid_1, sig_1_uuid, lp_1.policy_id}
+    merged_C_D_subelements = {sp_2.policy_id, dns_uuid_2, sig_1_uuid, lp_2.policy_id}
+    separate_E_subelements = {sp_3.policy_id, lp_2.policy_id}
     # Act
     config = transform(ux1=ux1).ux2_config
     merged_A_B = _find_policy_group_by_subelements(config.policy_groups, merged_A_B_subelements)

--- a/catalystwan/tests/templates/definitions/cisco_sig.json
+++ b/catalystwan/tests/templates/definitions/cisco_sig.json
@@ -24,7 +24,7 @@
                     "if-name": {
                         "vipObjectType": "object",
                         "vipType": "constant",
-                        "vipValue": "GigabitEthernet0/0"
+                        "vipValue": "ipsec255"
                     },
                     "auto": {
                         "vipObjectType": "object",
@@ -372,12 +372,12 @@
                     "endpoint-api-url": {
                         "vipObjectType": "object",
                         "vipType": "constant",
-                        "vipValue": "https://api.example.com/health"
+                        "vipValue": "http://api.example.com/health"
                     },
                     "threshold": {
                         "vipObjectType": "object",
                         "vipType": "constant",
-                        "vipValue": 5
+                        "vipValue": 100
                     },
                     "interval": {
                         "vipObjectType": "object",

--- a/catalystwan/tests/templates/models/cisco_secure_internet_gateway.py
+++ b/catalystwan/tests/templates/models/cisco_secure_internet_gateway.py
@@ -15,7 +15,7 @@ cisco_sig = CiscoSecureInternetGatewayModel(
     child_org_id="example_org",
     interface=[
         Interface(
-            if_name="GigabitEthernet0/0",
+            if_name="ipsec255",
             auto=True,
             shutdown=False,
             description="Main interface for SIG",
@@ -84,8 +84,8 @@ cisco_sig = CiscoSecureInternetGatewayModel(
     tracker=[
         Tracker(
             name="health-check-tracker",
-            endpoint_api_url="https://api.example.com/health",
-            threshold=5,
+            endpoint_api_url="http://api.example.com/health",
+            threshold=100,
             interval=60,
             multiplier=2,
             tracker_type="SIG",

--- a/catalystwan/utils/config_migration/creators/config_group_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_group_pusher.py
@@ -1,0 +1,109 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, cast
+from uuid import UUID
+
+from catalystwan.api.builders.feature_profiles.report import FeatureProfileBuildReport
+from catalystwan.endpoints.configuration_group import ProfileId
+from catalystwan.exceptions import ManagerHTTPError
+from catalystwan.models.configuration.config_migration import TransformedFeatureProfile, TransformedParcel
+from catalystwan.models.configuration.feature_profile.common import ProfileType
+from catalystwan.utils.config_migration.creators.pusher import Pusher, PusherConfig
+from catalystwan.utils.config_migration.factories.parcel_pusher import ParcelPusherFactory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConfigurationMapping:
+    feature_profile_map: Dict[UUID, TransformedFeatureProfile]
+    parcel_map: Dict[UUID, TransformedParcel]
+
+
+class ConfigGroupPusher(Pusher):
+    """Create sdwan Config Groups"""
+
+    def __init__(self, config: PusherConfig) -> None:
+        self.load_config(config)
+        self._create_config_map()
+
+    def push(self) -> None:
+        self._create_config_groups()
+
+    def _create_config_map(self) -> None:
+        self._config_map = ConfigurationMapping(
+            feature_profile_map={item.header.origin: item for item in self._ux2_config.feature_profiles},
+            parcel_map={item.header.origin: item for item in self._ux2_config.profile_parcels},
+        )
+
+    def _create_config_groups(self):
+        config_groups = self._ux2_config.config_groups
+        config_groups_length = len(config_groups)
+        for i, transformed_config_group in enumerate(config_groups):
+            self._progress(
+                f"Creating Configuration Group: {transformed_config_group.config_group.name}",
+                i + 1,
+                config_groups_length,
+            )
+            logger.debug(
+                f"Creating config group: {transformed_config_group.config_group.name} "
+                f"with origin uuid: {transformed_config_group.header.origin} "
+                f"and feature profiles: {transformed_config_group.header.subelements}"
+            )
+            config_group_payload = transformed_config_group.config_group
+            created_profiles = self._create_feature_profile_and_parcels(transformed_config_group.header.subelements)
+            config_group_payload.profiles = [ProfileId(id=profile.profile_uuid) for profile in created_profiles]
+            try:
+                cg_id = self._session.endpoints.configuration_group.create_config_group(config_group_payload).id
+            except ManagerHTTPError as e:
+                logger.error(f"Error occured during config group creation: {e}")
+                self._push_result.report.add_standalone_feature_profiles(feature_profiles=created_profiles)
+            else:
+                self._push_result.rollback.add_config_group(cg_id)
+                self._push_result.report.add_report(
+                    name=transformed_config_group.config_group.name,
+                    uuid=cg_id,
+                    feature_profiles=created_profiles,
+                )
+                self._push_context.id_lookup[transformed_config_group.header.origin] = cg_id
+
+    def _create_feature_profile_and_parcels(self, feature_profiles_ids: List[UUID]) -> List[FeatureProfileBuildReport]:
+        feature_profiles: List[FeatureProfileBuildReport] = []
+        for feature_profile_id in feature_profiles_ids:
+            transformed_feature_profile = self._config_map.feature_profile_map[feature_profile_id]
+            fp_name = transformed_feature_profile.feature_profile.name
+            logger.debug(
+                f"Creating feature profile: {fp_name} "
+                f"with origin uuid: {transformed_feature_profile.header.origin} "
+                f"and parcels: {transformed_feature_profile.header.subelements}"
+            )
+            profile_type = cast(ProfileType, transformed_feature_profile.header.type)
+            if profile_type in ["policy-object", "sig-security"]:
+                # TODO: Add builders for those profiles
+                logger.debug(f"Skipping profile: {fp_name}")
+                continue
+            pusher = ParcelPusherFactory.get_pusher(self._session, profile_type)
+            parcels = self._create_parcels_list(transformed_feature_profile)
+            try:
+                profile = pusher.push(transformed_feature_profile.feature_profile, parcels, self._config_map.parcel_map)
+                feature_profiles.append(profile)
+                self._push_result.rollback.add_feature_profile(profile.profile_uuid, profile_type)
+                self._push_context.id_lookup[feature_profile_id] = profile.profile_uuid
+            except ManagerHTTPError as e:
+                logger.error(f"Error occured during [{fp_name}] feature profile creation: {e}")
+            except Exception:
+                logger.critical(f"Unexpected error occured during [{fp_name}] feature profile creation", exc_info=True)
+        return feature_profiles
+
+    def _create_parcels_list(self, transformed_feature_profile: TransformedFeatureProfile) -> List[TransformedParcel]:
+        logger.debug(f"Creating parcels for feature profile: {transformed_feature_profile.feature_profile.name}")
+        parcels = []
+        for element_uuid in transformed_feature_profile.header.subelements:
+            transformed_parcel = self._config_map.parcel_map.get(element_uuid)
+            if not transformed_parcel:
+                # Device templates can have assigned feature templates but when we download the
+                # feature templates from the enpoint some templates don't exist in the response
+                logger.error(f"Parcel with origin uuid {element_uuid} not found in the config map")
+            else:
+                parcels.append(transformed_parcel)
+        return parcels

--- a/catalystwan/utils/config_migration/creators/config_group_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_group_pusher.py
@@ -59,7 +59,6 @@ class ConfigGroupPusher(Pusher):
                 logger.error(f"Error occured during config group creation: {e}")
                 self._push_result.report.add_standalone_feature_profiles(feature_profiles=created_profiles)
             else:
-                self._push_result.rollback.add_config_group(cg_id)
                 self._push_result.report.add_report(
                     name=transformed_config_group.config_group.name,
                     uuid=cg_id,

--- a/catalystwan/utils/config_migration/creators/config_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_pusher.py
@@ -60,6 +60,7 @@ class UX2ConfigPusher:
         self._topology_groups_pusher.push()
         self._policy_group_pusher.push()
         self._push_result.report.set_failed_push_parcels_flat_list()
+        self._push_result.set_groups_rollback()
         logger.debug(f"Configuration push completed. Rollback configuration {self._push_result}")
         return self._push_result
 

--- a/catalystwan/utils/config_migration/creators/config_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_pusher.py
@@ -1,34 +1,21 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
-from typing import Callable, Dict, List, cast
+from typing import Callable
 from uuid import UUID
 
-from pydantic import BaseModel
-
 from catalystwan.api.builders.feature_profiles.report import FeatureProfileBuildReport
-from catalystwan.endpoints.configuration_group import ProfileId
 from catalystwan.exceptions import ManagerHTTPError
-from catalystwan.models.configuration.config_migration import (
-    PushContext,
-    TransformedFeatureProfile,
-    TransformedParcel,
-    UX2Config,
-    UX2ConfigPushResult,
-)
-from catalystwan.models.configuration.feature_profile.common import ProfileType
+from catalystwan.models.configuration.config_migration import PushContext, UX2Config, UX2ConfigPushResult
 from catalystwan.session import ManagerSession
+from catalystwan.utils.config_migration.creators.config_group_pusher import ConfigGroupPusher
 from catalystwan.utils.config_migration.creators.groups_of_interests_pusher import GroupsOfInterestPusher
 from catalystwan.utils.config_migration.creators.localized_policy_pusher import LocalizedPolicyPusher
+from catalystwan.utils.config_migration.creators.policy_group_pusher import PolicyGroupPusher
+from catalystwan.utils.config_migration.creators.pusher import PusherConfig
 from catalystwan.utils.config_migration.creators.security_policy_pusher import SecurityPolicyPusher
 from catalystwan.utils.config_migration.creators.topology_groups_pusher import TopologyGroupsPusher
-from catalystwan.utils.config_migration.factories.parcel_pusher import ParcelPusherFactory
 
 logger = logging.getLogger(__name__)
-
-
-class ConfigurationMapping(BaseModel):
-    feature_profile_map: Dict[UUID, TransformedFeatureProfile]
-    parcel_map: Dict[UUID, TransformedParcel]
 
 
 class UX2ConfigPusher:
@@ -40,57 +27,38 @@ class UX2ConfigPusher:
     ) -> None:
         self._session = session
         self._push_context = PushContext()
-        self._config_map = self._create_config_map(ux2_config)
         self._push_result = UX2ConfigPushResult()
-
-        self._groups_of_interests_pusher = GroupsOfInterestPusher(
-            ux2_config=ux2_config,
-            session=session,
-            progress=progress,
-            push_result=self._push_result,
-            push_context=self._push_context,
-        )
-        self._localized_policy_feature_pusher = LocalizedPolicyPusher(
-            ux2_config=ux2_config,
-            session=session,
-            progress=progress,
-            push_result=self._push_result,
-            push_context=self._push_context,
-        )
-        self._security_policy_pusher = SecurityPolicyPusher(
-            ux2_config=ux2_config,
-            session=session,
-            progress=progress,
-            push_result=self._push_result,
-            push_context=self._push_context,
-        )
-        self._topology_groups_pusher = TopologyGroupsPusher(
-            ux2_config=ux2_config,
-            session=session,
-            progress=progress,
-            push_result=self._push_result,
-            push_context=self._push_context,
-        )
-
         self._ux2_config = ux2_config
         self._progress = progress
+        self._configure_pushers()
 
-    def _create_config_map(self, ux2_config: UX2Config) -> ConfigurationMapping:
-        return ConfigurationMapping(
-            feature_profile_map={item.header.origin: item for item in ux2_config.feature_profiles},
-            parcel_map={item.header.origin: item for item in ux2_config.profile_parcels},
+    def _configure_pushers(self):
+        config = PusherConfig(
+            ux2_config=self._ux2_config,
+            session=self._session,
+            push_result=self._push_result,
+            push_context=self._push_context,
+            progress=self._progress,
         )
+        self._config_group_pusher = ConfigGroupPusher(config)
+        self._groups_of_interests_pusher = GroupsOfInterestPusher(config)
+        self._localized_policy_feature_pusher = LocalizedPolicyPusher(config)
+        self._security_policy_pusher = SecurityPolicyPusher(config)
+        self._topology_groups_pusher = TopologyGroupsPusher(config)
+        self._policy_group_pusher = PolicyGroupPusher(config)
 
     def push(self) -> UX2ConfigPushResult:
+        # Do not change the order of the push
         self._create_sigs()
         self._create_cloud_credentials()
         self._create_thread_grid_api()
         self._create_cflowd()
-        self._create_config_groups()
+        self._config_group_pusher.push()
         self._groups_of_interests_pusher.push()
         self._localized_policy_feature_pusher.push()
         self._security_policy_pusher.push()
         self._topology_groups_pusher.push()
+        self._policy_group_pusher.push()
         self._push_result.report.set_failed_push_parcels_flat_list()
         logger.debug(f"Configuration push completed. Rollback configuration {self._push_result}")
         return self._push_result
@@ -160,75 +128,3 @@ class UX2ConfigPusher:
             self._session.endpoints.network_hierarchy.create_cflowd(UUID(node.id), self._ux2_config.cflowd)
         except ManagerHTTPError as e:
             logger.error(f"Error occured during Cflowd migration: {e}")
-
-    def _create_config_groups(self):
-        config_groups = self._ux2_config.config_groups
-        config_groups_length = len(config_groups)
-        for i, transformed_config_group in enumerate(config_groups):
-            self._progress(
-                f"Creating Configuration Group: {transformed_config_group.config_group.name}",
-                i + 1,
-                config_groups_length,
-            )
-            logger.debug(
-                f"Creating config group: {transformed_config_group.config_group.name} "
-                f"with origin uuid: {transformed_config_group.header.origin} "
-                f"and feature profiles: {transformed_config_group.header.subelements}"
-            )
-            config_group_payload = transformed_config_group.config_group
-            created_profiles = self._create_feature_profile_and_parcels(transformed_config_group.header.subelements)
-            config_group_payload.profiles = [ProfileId(id=profile.profile_uuid) for profile in created_profiles]
-            try:
-                cg_id = self._session.endpoints.configuration_group.create_config_group(config_group_payload).id
-            except ManagerHTTPError as e:
-                logger.error(f"Error occured during config group creation: {e}")
-                self._push_result.report.add_standalone_feature_profiles(feature_profiles=created_profiles)
-            else:
-                self._push_result.rollback.add_config_group(cg_id)
-                self._push_result.report.add_report(
-                    name=transformed_config_group.config_group.name,
-                    uuid=cg_id,
-                    feature_profiles=created_profiles,
-                )
-                self._push_context.id_lookup[transformed_config_group.header.origin] = cg_id
-
-    def _create_feature_profile_and_parcels(self, feature_profiles_ids: List[UUID]) -> List[FeatureProfileBuildReport]:
-        feature_profiles: List[FeatureProfileBuildReport] = []
-        for feature_profile_id in feature_profiles_ids:
-            transformed_feature_profile = self._config_map.feature_profile_map[feature_profile_id]
-            fp_name = transformed_feature_profile.feature_profile.name
-            logger.debug(
-                f"Creating feature profile: {fp_name} "
-                f"with origin uuid: {transformed_feature_profile.header.origin} "
-                f"and parcels: {transformed_feature_profile.header.subelements}"
-            )
-            profile_type = cast(ProfileType, transformed_feature_profile.header.type)
-            if profile_type in ["policy-object", "sig-security"]:
-                # TODO: Add builders for those profiles
-                logger.debug(f"Skipping profile: {fp_name}")
-                continue
-            pusher = ParcelPusherFactory.get_pusher(self._session, profile_type)
-            parcels = self._create_parcels_list(transformed_feature_profile)
-            try:
-                profile = pusher.push(transformed_feature_profile.feature_profile, parcels, self._config_map.parcel_map)
-                feature_profiles.append(profile)
-                self._push_result.rollback.add_feature_profile(profile.profile_uuid, profile_type)
-                self._push_context.id_lookup[feature_profile_id] = profile.profile_uuid
-            except ManagerHTTPError as e:
-                logger.error(f"Error occured during [{fp_name}] feature profile creation: {e}")
-            except Exception:
-                logger.critical(f"Unexpected error occured during [{fp_name}] feature profile creation", exc_info=True)
-        return feature_profiles
-
-    def _create_parcels_list(self, transformed_feature_profile: TransformedFeatureProfile) -> List[TransformedParcel]:
-        logger.debug(f"Creating parcels for feature profile: {transformed_feature_profile.feature_profile.name}")
-        parcels = []
-        for element_uuid in transformed_feature_profile.header.subelements:
-            transformed_parcel = self._config_map.parcel_map.get(element_uuid)
-            if not transformed_parcel:
-                # Device templates can have assigned feature templates but when we download the
-                # feature templates from the enpoint some templates don't exist in the response
-                logger.error(f"Parcel with origin uuid {element_uuid} not found in the config map")
-            else:
-                parcels.append(transformed_parcel)
-        return parcels

--- a/catalystwan/utils/config_migration/creators/config_pusher.py
+++ b/catalystwan/utils/config_migration/creators/config_pusher.py
@@ -112,6 +112,7 @@ class UX2ConfigPusher:
                     )
                 )
                 self._push_result.rollback.add_feature_profile(profile_uuid, "sig-security")
+                self._push_context.policy_group_feature_profiles_id_lookup[sig.header.origin] = profile_uuid
             except ManagerHTTPError as e:
                 logger.error(f"Error occured during sig creation: {e}")
         self._push_result.report.add_standalone_feature_profiles(profiles)

--- a/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
+++ b/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
@@ -241,6 +241,9 @@ class LocalizedPolicyPusher:
                 report = app_prio_builder.build()
                 self._push_result.rollback.add_feature_profile(report.profile_uuid, app_prio_profile.header.type)
                 app_prio_reports.append(report)
+                self._push_context.policy_group_feature_profiles_id_lookup[
+                    app_prio_profile.header.origin
+                ] = report.profile_uuid
             except ManagerHTTPError as e:
                 logger.error(f"Error occured during Application Priority profile creation: {e.info}")
         self._push_result.report.add_standalone_feature_profiles(app_prio_reports)

--- a/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
+++ b/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
-from typing import Callable, Dict, List, Literal, Tuple, Union, cast
+from typing import Dict, List, Literal, Tuple, Union, cast
 from uuid import UUID
 
 from pydantic import Field, ValidationError
@@ -10,13 +10,7 @@ from catalystwan.api.builders.feature_profiles.builder_factory import FeaturePro
 from catalystwan.api.builders.feature_profiles.report import FeatureProfileBuildReport
 from catalystwan.endpoints.configuration_group import ConfigGroup
 from catalystwan.exceptions import ManagerErrorInfo, ManagerHTTPError
-from catalystwan.models.configuration.config_migration import (
-    PushContext,
-    TransformedFeatureProfile,
-    TransformedParcel,
-    UX2Config,
-    UX2ConfigPushResult,
-)
+from catalystwan.models.configuration.config_migration import TransformedFeatureProfile, TransformedParcel
 from catalystwan.models.configuration.feature_profile.parcel import list_types
 from catalystwan.models.configuration.feature_profile.sdwan.acl.ipv4acl import Ipv4AclParcel
 from catalystwan.models.configuration.feature_profile.sdwan.acl.ipv6acl import Ipv6AclParcel
@@ -30,7 +24,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.application_priority
 from catalystwan.models.configuration.feature_profile.sdwan.service.route_policy import RoutePolicyParcel
 from catalystwan.models.configuration.feature_profile.sdwan.system.device_access import DeviceAccessIPv4Parcel
 from catalystwan.models.configuration.feature_profile.sdwan.system.device_access_ipv6 import DeviceAccessIPv6Parcel
-from catalystwan.session import ManagerSession
+from catalystwan.utils.config_migration.creators.pusher import Pusher, PusherConfig
 from catalystwan.utils.config_migration.creators.references_updater import update_parcel_references
 
 _AnyApplicationPriorityPolicyParcel = Annotated[
@@ -67,7 +61,7 @@ _ProfileInfo = Tuple[_LocalizedPolicyProfileTypes, UUID, str, List[TransformedPa
 logger = logging.getLogger(__name__)
 
 
-class LocalizedPolicyPusher:
+class LocalizedPolicyPusher(Pusher):
     """
     1. Associate selected Config Group with Default_Policy_Object_Profile
     2. Update selected Feature Profiles by pushing Parcels originating from Localized Policy items (eg. acl, route)
@@ -75,22 +69,11 @@ class LocalizedPolicyPusher:
     and Default_Policy_Object_Profile is populated with Groups of Interest
     """
 
-    def __init__(
-        self,
-        ux2_config: UX2Config,
-        session: ManagerSession,
-        push_result: UX2ConfigPushResult,
-        push_context: PushContext,
-        progress: Callable[[str, int, int], None],
-    ) -> None:
-        self._ux2_config = ux2_config
-        self._session = session
-        self._cg_api = session.api.config_group
-        self._app_prio_api = session.api.sdwan_feature_profiles.application_priority
-        self._push_result: UX2ConfigPushResult = push_result
-        self._push_context = push_context
-        self._progress: Callable[[str, int, int], None] = progress
+    def __init__(self, config: PusherConfig) -> None:
+        self.load_config(config)
         self._parcel_by_id = self._create_parcel_by_id_lookup()
+        self._app_prio_api = self._session.api.sdwan_feature_profiles.application_priority
+        self._cg_api = self._session.api.config_group
 
     def _create_parcel_by_id_lookup(self) -> Dict[UUID, TransformedParcel]:
         lookup: Dict[UUID, TransformedParcel] = dict()

--- a/catalystwan/utils/config_migration/creators/policy_group_pusher.py
+++ b/catalystwan/utils/config_migration/creators/policy_group_pusher.py
@@ -1,0 +1,47 @@
+import logging
+
+from catalystwan.exceptions import ManagerHTTPError
+from catalystwan.models.configuration.config_migration import TransformedPolicyGroup
+from catalystwan.models.configuration.policy_group import PolicyGroup
+from catalystwan.utils.config_migration.creators.pusher import Pusher, PusherConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyGroupPusher(Pusher):
+    """Create Policy Groups that aggregate all the feature profiles that were the part of the same Device Template."""
+
+    def __init__(self, config: PusherConfig) -> None:
+        self.load_config(config)
+
+    def push(self) -> None:
+        pg_len = len(self._ux2_config.policy_groups)
+        for i, pg in enumerate(self._ux2_config.policy_groups):
+            self._progress(f"Creating Policy Group: {pg.policy_group.name}", i + 1, pg_len)
+            self._replace_subelements_with_pushed_feature_profiles(pg)
+            self._push_policy_group(pg.policy_group)
+
+    def _replace_subelements_with_pushed_feature_profiles(self, policy_group: TransformedPolicyGroup) -> None:
+        for ref in policy_group.header.subelements:
+            if id_ := self._push_context.policy_group_feature_profiles_id_lookup.get(ref):
+                policy_group.policy_group.add_profile(profile_uuid=id_)
+            else:
+                logger.warning(f"Could not find a pushed feature profile with ref {ref}")
+
+    def _push_policy_group(
+        self,
+        policy_group: PolicyGroup,
+    ) -> None:
+        try:
+            uuid = self._session.endpoints.configuration.policy_group.create_policy_group(policy_group).id
+            if policy_group.profiles:
+                associated_feature_profiles = self._push_result.report.get_standalone_feature_profiles_by_ids(
+                    set([p.id for p in policy_group.profiles])
+                )
+            else:
+                associated_feature_profiles = []
+            self._push_result.report.add_pg_report(
+                policy_group.name, uuid, feature_profiles=associated_feature_profiles
+            )
+        except ManagerHTTPError as e:
+            logger.error(f"Failed to push policy group {policy_group.name}: {e}")

--- a/catalystwan/utils/config_migration/creators/pusher.py
+++ b/catalystwan/utils/config_migration/creators/pusher.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from catalystwan.models.configuration.config_migration import PushContext, UX2Config, UX2ConfigPushResult
+from catalystwan.session import ManagerSession
+
+
+@dataclass
+class PusherConfig:
+    ux2_config: UX2Config
+    session: ManagerSession
+    push_result: UX2ConfigPushResult
+    push_context: PushContext
+    progress: Callable[[str, int, int], None]
+
+
+class Pusher:
+    def load_config(self, config: PusherConfig) -> None:
+        self._ux2_config = config.ux2_config
+        self._session = config.session
+        self._push_result = config.push_result
+        self._push_context = config.push_context
+        self._progress: Callable[[str, int, int], None] = config.progress

--- a/catalystwan/utils/config_migration/creators/security_policy_pusher.py
+++ b/catalystwan/utils/config_migration/creators/security_policy_pusher.py
@@ -1,42 +1,30 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
-from typing import Callable, cast
+from typing import cast
 from uuid import UUID
 
 from catalystwan.api.builders.feature_profiles.report import FeatureProfileBuildReport
 from catalystwan.exceptions import ManagerHTTPError
-from catalystwan.models.configuration.config_migration import (
-    PushContext,
-    TransformedParcel,
-    UX2Config,
-    UX2ConfigPushResult,
-)
+from catalystwan.models.configuration.config_migration import TransformedParcel
 from catalystwan.models.configuration.feature_profile.parcel import AnyDnsSecurityParcel, list_types
 from catalystwan.models.configuration.feature_profile.sdwan.embedded_security import NgfirewallParcel, PolicyParcel
 from catalystwan.models.configuration.feature_profile.sdwan.embedded_security.policy import NgFirewallContainer
-from catalystwan.session import ManagerSession
+from catalystwan.utils.config_migration.creators.pusher import Pusher, PusherConfig
 
 from .references_updater import update_parcel_references
 
 logger = logging.getLogger(__name__)
 
 
-class SecurityPolicyPusher:
+class SecurityPolicyPusher(Pusher):
     def __init__(
         self,
-        ux2_config: UX2Config,
-        session: ManagerSession,
-        push_result: UX2ConfigPushResult,
-        push_context: PushContext,
-        progress: Callable[[str, int, int], None],
+        config: PusherConfig,
     ) -> None:
-        self._ux2_config = ux2_config
-        self._dns_security_api = session.api.sdwan_feature_profiles.dns_security
-        self._embedded_security_api = session.api.sdwan_feature_profiles.embedded_security
-        self._app_profile_api = session.api.sdwan_feature_profiles.application_priority
-        self._push_result: UX2ConfigPushResult = push_result
-        self._progress: Callable[[str, int, int], None] = progress
-        self.push_context = push_context
+        self.load_config(config)
+        self._dns_security_api = self._session.api.sdwan_feature_profiles.dns_security
+        self._app_profile_api = self._session.api.sdwan_feature_profiles.application_priority
+        self._embedded_security_api = self._session.api.sdwan_feature_profiles.embedded_security
 
     def push(self) -> None:
         self.push_dns_security_policies()
@@ -58,12 +46,12 @@ class SecurityPolicyPusher:
         self, profile_id: UUID, firewall: TransformedParcel, report: FeatureProfileBuildReport
     ) -> None:
         parcel = cast(NgfirewallParcel, firewall.parcel)
-        parcel = update_parcel_references(parcel, self.push_context.id_lookup)
+        parcel = update_parcel_references(parcel, self._push_context.id_lookup)
 
         try:
             fw_id = self._embedded_security_api.create_parcel(profile_id, parcel).id
             report.add_created_parcel(parcel.parcel_name, fw_id)
-            self.push_context.id_lookup[firewall.header.origin] = fw_id
+            self._push_context.id_lookup[firewall.header.origin] = fw_id
         except ManagerHTTPError as e:
             logger.error(f"Error occured during creating NGFirewall in embedded security profile: {e.info}")
             report.add_failed_parcel(parcel_name=parcel.parcel_name, parcel_type=parcel.type_, error_info=e.info)
@@ -74,11 +62,11 @@ class SecurityPolicyPusher:
         parcel = cast(PolicyParcel, policy.parcel)
 
         try:
-            parcel = update_parcel_references(parcel, self.push_context.id_lookup)
+            parcel = update_parcel_references(parcel, self._push_context.id_lookup)
             security_policy_parcel_id = self._embedded_security_api.create_parcel(profile_id, parcel).id
             report.add_created_parcel(parcel.parcel_name, security_policy_parcel_id)
-            self.push_context.id_lookup[policy.header.origin] = security_policy_parcel_id
-            self.push_context.policy_group_feature_profiles_id_lookup[policy.header.origin] = profile_id
+            self._push_context.id_lookup[policy.header.origin] = security_policy_parcel_id
+            self._push_context.policy_group_feature_profiles_id_lookup[policy.header.origin] = profile_id
         except ManagerHTTPError as e:
             logger.error(f"Error occured during creating PolicyParcel in embedded security profile: {e.info}")
             report.add_failed_parcel(parcel_name=parcel.parcel_name, parcel_type=parcel.type_, error_info=e.info)
@@ -127,7 +115,7 @@ class SecurityPolicyPusher:
             self._progress(msg, i + 1, len(dns_security_policies))
 
             parcel = cast(AnyDnsSecurityParcel, dns_security_policy.parcel)
-            parcel = update_parcel_references(parcel, self.push_context.id_lookup)
+            parcel = update_parcel_references(parcel, self._push_context.id_lookup)
 
             try:
                 profile_id = self._dns_security_api.create_profile(parcel.parcel_name, parcel.parcel_description).id
@@ -145,8 +133,8 @@ class SecurityPolicyPusher:
 
             try:
                 parcel_id = self._dns_security_api.create_parcel(profile_id, parcel).id
-                self.push_context.id_lookup[dns_security_policy.header.origin] = parcel_id
-                self.push_context.policy_group_feature_profiles_id_lookup[
+                self._push_context.id_lookup[dns_security_policy.header.origin] = parcel_id
+                self._push_context.policy_group_feature_profiles_id_lookup[
                     dns_security_policy.header.origin
                 ] = profile_id
                 feature_profile_report.add_created_parcel(dns_security_policy.parcel.parcel_name, parcel_id)

--- a/catalystwan/utils/config_migration/creators/security_policy_pusher.py
+++ b/catalystwan/utils/config_migration/creators/security_policy_pusher.py
@@ -78,6 +78,7 @@ class SecurityPolicyPusher:
             security_policy_parcel_id = self._embedded_security_api.create_parcel(profile_id, parcel).id
             report.add_created_parcel(parcel.parcel_name, security_policy_parcel_id)
             self.push_context.id_lookup[policy.header.origin] = security_policy_parcel_id
+            self.push_context.policy_group_feature_profiles_id_lookup[policy.header.origin] = profile_id
         except ManagerHTTPError as e:
             logger.error(f"Error occured during creating PolicyParcel in embedded security profile: {e.info}")
             report.add_failed_parcel(parcel_name=parcel.parcel_name, parcel_type=parcel.type_, error_info=e.info)
@@ -145,6 +146,9 @@ class SecurityPolicyPusher:
             try:
                 parcel_id = self._dns_security_api.create_parcel(profile_id, parcel).id
                 self.push_context.id_lookup[dns_security_policy.header.origin] = parcel_id
+                self.push_context.policy_group_feature_profiles_id_lookup[
+                    dns_security_policy.header.origin
+                ] = profile_id
                 feature_profile_report.add_created_parcel(dns_security_policy.parcel.parcel_name, parcel_id)
             except ManagerHTTPError as e:
                 logger.error(f"Error occured during DNS Security policy creation: {e.info}")

--- a/catalystwan/utils/config_migration/creators/topology_groups_pusher.py
+++ b/catalystwan/utils/config_migration/creators/topology_groups_pusher.py
@@ -75,7 +75,6 @@ class TopologyGroupsPusher(Pusher):
             group.add_profiles([profile_id, self._push_context.default_policy_object_profile_id])
             try:
                 group_id = group_api.create(group).id
-                self._push_result.rollback.add_topology_group(group_id)
                 group_report = TopologyGroupReport(name=group.name, uuid=group_id, feature_profiles=[profile_report])
                 self._push_result.report.topology_groups.append(group_report)
                 self._push_context.id_lookup[ttg.header.origin] = group_id

--- a/catalystwan/utils/config_migration/creators/topology_groups_pusher.py
+++ b/catalystwan/utils/config_migration/creators/topology_groups_pusher.py
@@ -1,42 +1,24 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 import logging
-from typing import Callable
 
 from catalystwan.api.builders.feature_profiles.report import FeatureProfileBuildReport
 from catalystwan.exceptions import ManagerHTTPError
-from catalystwan.models.configuration.config_migration import (
-    PushContext,
-    TopologyGroupReport,
-    UX2Config,
-    UX2ConfigPushResult,
-)
+from catalystwan.models.configuration.config_migration import TopologyGroupReport
 from catalystwan.models.configuration.feature_profile.sdwan.topology.custom_control import CustomControlParcel
 from catalystwan.models.configuration.feature_profile.sdwan.topology.hubspoke import HubSpokeParcel
 from catalystwan.models.configuration.feature_profile.sdwan.topology.mesh import MeshParcel
-from catalystwan.session import ManagerSession
+from catalystwan.utils.config_migration.creators.pusher import Pusher, PusherConfig
 from catalystwan.utils.config_migration.creators.references_updater import update_parcel_references
 
 logger = logging.getLogger(__name__)
 
 
-class TopologyGroupsPusher:
-    def __init__(
-        self,
-        ux2_config: UX2Config,
-        session: ManagerSession,
-        push_result: UX2ConfigPushResult,
-        push_context: PushContext,
-        progress: Callable[[str, int, int], None],
-    ) -> None:
-        self._ux2_config = ux2_config
-        self._session = session
-        self._push_result = push_result
-        self._push_context = push_context
-        self._progress = progress
-        self.push_context = push_context
+class TopologyGroupsPusher(Pusher):
+    def __init__(self, config: PusherConfig) -> None:
+        self.load_config(config)
 
     def push(self) -> None:
-        if self.push_context.default_policy_object_profile_id is None:
+        if self._push_context.default_policy_object_profile_id is None:
             logger.error("Cannot create Topology Group without Default Policy Object Profile")
             return
         profile_api = self._session.api.sdwan_feature_profiles.topology
@@ -71,12 +53,12 @@ class TopologyGroupsPusher:
 
             # Push Topology Feature Profile Parcels
             for transformed_parcel in self._ux2_config.list_transformed_parcels_with_origin(ttp.header.subelements):
-                parcel = update_parcel_references(transformed_parcel.parcel, self.push_context.id_lookup)
+                parcel = update_parcel_references(transformed_parcel.parcel, self._push_context.id_lookup)
                 if isinstance(parcel, (CustomControlParcel, HubSpokeParcel, MeshParcel)):
                     try:
                         parcel_id = profile_api.create_parcel(profile_id, parcel).id
                         profile_report.add_created_parcel(parcel_name=parcel.parcel_name, parcel_uuid=parcel_id)
-                        self.push_context.id_lookup[transformed_parcel.header.origin] = parcel_id
+                        self._push_context.id_lookup[transformed_parcel.header.origin] = parcel_id
                     except ManagerHTTPError as e:
                         logger.error(f"Error occured during topology profile parcel creation: {e}")
                         profile_report.add_failed_parcel(
@@ -90,7 +72,7 @@ class TopologyGroupsPusher:
 
             # Push Topology Group
             group = ttg.topology_group
-            group.add_profiles([profile_id, self.push_context.default_policy_object_profile_id])
+            group.add_profiles([profile_id, self._push_context.default_policy_object_profile_id])
             try:
                 group_id = group_api.create(group).id
                 self._push_result.rollback.add_topology_group(group_id)

--- a/catalystwan/utils/config_migration/runner.py
+++ b/catalystwan/utils/config_migration/runner.py
@@ -32,6 +32,7 @@ class ConfigMigrationRunner:
     collect: bool = True
     push: bool = True
     rollback: bool = False
+    add_suffix: bool = True
     dt_filter: str = ".*"
     ft_filter: str = ".*"
     lp_filter: str = ".*"
@@ -227,7 +228,7 @@ class ConfigMigrationRunner:
             # transform to ux2 and dump to json file
             _ux1 = self.load_collected_config()
             self.filter_ux1(_ux1)
-            _transform_result = transform(_ux1, True)
+            _transform_result = transform(_ux1, self.add_suffix)
             with open(self.ux2_dump, "w") as f:
                 f.write(_transform_result.model_dump_json(exclude_none=True, by_alias=True, indent=4, warnings=False))
 

--- a/catalystwan/utils/config_migration/runner.py
+++ b/catalystwan/utils/config_migration/runner.py
@@ -33,7 +33,7 @@ class ConfigMigrationRunner:
     push: bool = True
     rollback: bool = False
     dt_filter: str = ".*"
-    artifact_dir = Path(DEFAULT_ARTIFACT_DIR)
+    artifact_dir = Path(DEFAULT_ARTIFACT_DIR).absolute()
     progress: Callable[[str, int, int], None] = log_progress
 
     def __post_init__(self) -> None:
@@ -45,6 +45,14 @@ class ConfigMigrationRunner:
         self.transform_schema_dump: Path = self.artifact_dir / Path("transform-result-schema.json")
         self.push_schema_dump: Path = self.artifact_dir / Path("push-result-schema.json")
         self.dt_pattern: re.Pattern = re.compile(self.dt_filter)
+
+    def set_dump_prefix(self, prefix: str) -> None:
+        self.ux1_dump = self.artifact_dir / Path(f"{prefix}-ux1.json")
+        self.ux2_dump = self.artifact_dir / Path(f"{prefix}-ux2.json")
+        self.ux2_push_dump = self.artifact_dir / Path(f"{prefix}-ux2-push-result.json")
+        self.ux1_schema_dump = self.artifact_dir / Path(f"{prefix}-ux1-schema.json")
+        self.transform_schema_dump = self.artifact_dir / Path(f"{prefix}-transform-result-schema.json")
+        self.push_schema_dump = self.artifact_dir / Path(f"{prefix}-push-result-schema.json")
 
     @staticmethod
     def collect_only(session: ManagerSession, filter: str = ".*") -> "ConfigMigrationRunner":
@@ -165,6 +173,8 @@ class ConfigMigrationRunner:
             if self.collect:
                 ux1 = collect_ux1_config(session, self.progress)
                 # ux1.templates = UX1Templates()
+                logger.warning(self.ux1_dump)
+                print(self.ux1_dump)
                 with open(self.ux1_dump, "w") as f:
                     f.write(ux1.model_dump_json(exclude_none=True, by_alias=True, indent=4, warnings=False))
 

--- a/catalystwan/utils/config_migration/runner.py
+++ b/catalystwan/utils/config_migration/runner.py
@@ -34,9 +34,9 @@ class ConfigMigrationRunner:
     rollback: bool = False
     dt_filter: str = ".*"
     ft_filter: str = ".*"
-    localized_filter: str = ".*"
-    centralized_filter: str = ".*"
-    security_filter: str = ".*"
+    lp_filter: str = ".*"
+    cp_filter: str = ".*"
+    sp_filter: str = ".*"
     artifact_dir = Path(DEFAULT_ARTIFACT_DIR)
     progress: Callable[[str, int, int], None] = log_progress
 
@@ -48,7 +48,6 @@ class ConfigMigrationRunner:
         self.ux1_schema_dump: Path = self.artifact_dir / Path("ux1-schema.json")
         self.transform_schema_dump: Path = self.artifact_dir / Path("transform-result-schema.json")
         self.push_schema_dump: Path = self.artifact_dir / Path("push-result-schema.json")
-        self.dt_pattern: re.Pattern = re.compile(self.dt_filter)
 
     def set_dump_prefix(self, prefix: str) -> None:
         self.ux1_dump = self.artifact_dir / Path(f"{prefix}-ux1.json")
@@ -62,16 +61,25 @@ class ConfigMigrationRunner:
         self,
         dt_filter: str = ".*",
         ft_filter: str = ".*",
-        localized_filter: str = ".*",
-        centralized_filter: str = ".*",
-        security_filter: str = ".*",
+        lp_filter: str = ".*",
+        cp_filter: str = ".*",
+        sp_filter: str = ".*",
     ) -> None:
+        """Set the filters for the device templates, feature templates,
+        localized policies, centralized policies, and security policies
+
+        Args:
+            dt_filter (str, optional): Device Template filter. Defaults to ".*".
+            ft_filter (str, optional): Feature Template filter. Defaults to ".*".
+            lp_filter (str, optional): Localized Policy filter. Defaults to ".*".
+            cp_filter (str, optional): Centralized Policy filter. Defaults to ".*".
+            sp_filter (str, optional): Security Policy filter. Defaults to ".*".
+        """
         self.dt_filter = dt_filter
         self.ft_filter = ft_filter
-        self.localized_filter = localized_filter
-        self.centralized_filter = centralized_filter
-        self.security_filter = security_filter
-        self.dt_pattern = re.compile(self.dt_filter)
+        self.lp_filter = lp_filter
+        self.cp_filter = cp_filter
+        self.sp_filter = sp_filter
 
     @staticmethod
     def collect_only(session: ManagerSession, filter: str = ".*") -> "ConfigMigrationRunner":
@@ -189,26 +197,23 @@ class ConfigMigrationRunner:
     def filter_ux1(self, ux1: UX1Config) -> None:
         """Filter out the templates and policies based on the filters"""
         _filtered_dts = [
-            dt for dt in ux1.templates.device_templates if re.search(self.dt_pattern, dt.template_name) is not None
+            dt for dt in ux1.templates.device_templates if re.search(self.dt_filter, dt.template_name) is not None
         ]
         ux1.templates.device_templates = _filtered_dts
-        _filtered_fts = [
-            ft for ft in ux1.templates.feature_templates if re.search(self.ft_filter, ft.name) is not None
-        ]
+        _filtered_fts = [ft for ft in ux1.templates.feature_templates if re.search(self.ft_filter, ft.name) is not None]
         ux1.templates.feature_templates = _filtered_fts
         _filtered_localized = [
-            p for p in ux1.policies.localized_policies if re.search(self.localized_filter, p.policy_name) is not None
+            p for p in ux1.policies.localized_policies if re.search(self.lp_filter, p.policy_name) is not None
         ]
         ux1.policies.localized_policies = _filtered_localized
         _filtered_centralized = [
-            p for p in ux1.policies.centralized_policies if re.search(self.centralized_filter, p.policy_name) is not None
+            p for p in ux1.policies.centralized_policies if re.search(self.cp_filter, p.policy_name) is not None
         ]
         ux1.policies.centralized_policies = _filtered_centralized
         _filtered_security = [
-            p for p in ux1.policies.security_policies if re.search(self.security_filter, p.policy_name) is not None
+            p for p in ux1.policies.security_policies if re.search(self.sp_filter, p.policy_name) is not None
         ]
         ux1.policies.security_policies = _filtered_security
-
 
     def run(self):
         with self.session.login() as session:

--- a/catalystwan/utils/config_migration/steps/transform.py
+++ b/catalystwan/utils/config_migration/steps/transform.py
@@ -403,6 +403,10 @@ class PolicyGroupMetadataMerger:
         self.policy_groups = policies_metadata
         self.policy_map: Dict[Set[UUID], PolicyGroupMetadata] = dict()
 
+    def remove_policies_with_no_subelements(self):
+        """The policy groups with no subelements, no need to create empty groups."""
+        self.policy_groups = [policy for policy in self.policy_groups if policy.policy_group_subelements]
+
     def merge_by_subelements(self):
         """Merge Policy Groups with the same subelements into one."""
         for policy in self.policy_groups:

--- a/catalystwan/utils/config_migration/steps/transform.py
+++ b/catalystwan/utils/config_migration/steps/transform.py
@@ -395,7 +395,13 @@ class PolicyGroupMetadataCreator:
         if not security:
             return set()
 
-        return security.get_assemby_item_uuids()
+        # Return self and dns security policy
+        # SecurityPolicy converts to PolicyParcel and creates feature profile
+        # DNSSecurity converts to DNSParcel and creates feature profile
+        dns_uuid = next((a for a in security.policy_definition.assembly if a.type == "DNSSecurity"), None)
+        if dns_uuid is None:
+            return set([security_uuid])
+        return set([security_uuid, dns_uuid.definition_id])
 
 
 class PolicyGroupMetadataMerger:

--- a/catalystwan/utils/config_migration/steps/transform.py
+++ b/catalystwan/utils/config_migration/steps/transform.py
@@ -382,10 +382,10 @@ class PolicyGroupMetadataCreator:
             return set()
 
         policy_c = self.ux1.policies.get_centralized_policy_by_id(policy_uuid)
-        policy_l = self.ux1.policies.get_localized_policy_by_id(policy_uuid)
+        # policy_l = self.ux1.policies.get_localized_policy_by_id(policy_uuid)
         if policy_c:
             return set()
-        return policy_uuid
+        return {policy_uuid}
 
     def _get_security_elements(self, security_uuid: Optional[UUID]) -> Set[UUID]:
         if not security_uuid:

--- a/catalystwan/utils/config_migration/steps/transform.py
+++ b/catalystwan/utils/config_migration/steps/transform.py
@@ -339,7 +339,7 @@ def remove_unused_feature_templates(ux1: UX1Config, used_feature_templates: Set[
 class PolicyGroupMetadata:
     def __init__(self, transformed_policy_group: TransformedPolicyGroup, policy_group_subelements: Set[UUID]):
         self.transformed_policy_group = transformed_policy_group
-        self.policy_group_subelements = policy_group_subelements
+        self.policy_group_subelements = frozenset(policy_group_subelements)
 
 
 class PolicyGroupMetadataCreator:
@@ -354,12 +354,12 @@ class PolicyGroupMetadataCreator:
         policy_elements_uuids = self._get_policy_elements(dt.get_policy_uuid())
         security_elements_uuids = self._get_security_elements(dt.get_security_policy_uuid())
         sig_uuid = dt.get_sig_template_uuid()
-        sig_uuid_set = set(sig_uuid) if sig_uuid else set()
+        sig_uuid_set = set([sig_uuid]) if sig_uuid else set()
         policy_group_subelements = set().union(policy_elements_uuids, security_elements_uuids, sig_uuid_set)
         transformed_policy_group = TransformedPolicyGroup(
             header=TransformHeader(
                 type="policy_group",
-                origin=dt.template_id,
+                origin=UUID(dt.template_id),
                 origname=dt.template_name,
                 subelements=policy_group_subelements,
                 info=[f"Policy Group created from Device Template. Included elements: {policy_group_subelements}"],
@@ -403,7 +403,7 @@ class PolicyGroupMetadataCreator:
 class PolicyGroupMetadataMerger:
     def __init__(self, policies_metadata: List[PolicyGroupMetadata]):
         self.policy_groups = policies_metadata
-        self.policy_map: Dict[Set[UUID], PolicyGroupMetadata] = set()
+        self.policy_map: Dict[Set[UUID], PolicyGroupMetadata] = dict()
 
     def merge_by_subelements(self):
         """Merge Policy Groups with the same subelements into one."""

--- a/catalystwan/utils/config_migration/steps/transform.py
+++ b/catalystwan/utils/config_migration/steps/transform.py
@@ -377,17 +377,15 @@ class PolicyGroupMetadataCreator:
         self.policies.append(self.create(dt))
 
     def _get_policy_elements(self, policy_uuid: Optional[UUID]) -> Set[UUID]:
-        """From current knowledge all policy elements are not used in Policy Groups."""
-        # if not policy_uuid:
-        #     return set()
+        """Localized policy creates application-priority profile"""
+        if not policy_uuid:
+            return set()
 
-        # policy_c = self.ux1.policies.get_centralized_policy_by_id(policy_uuid)
-        # policy_l = self.ux1.policies.get_localized_policy_by_id(policy_uuid)
-        # policy = policy_c or policy_l
-
-        # if not policy:
-        #     return set()
-        return set()
+        policy_c = self.ux1.policies.get_centralized_policy_by_id(policy_uuid)
+        policy_l = self.ux1.policies.get_localized_policy_by_id(policy_uuid)
+        if policy_c:
+            return set()
+        return policy_uuid
 
     def _get_security_elements(self, security_uuid: Optional[UUID]) -> Set[UUID]:
         if not security_uuid:

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -360,6 +360,7 @@ def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult
     # Add Policy Groups
     policies_metadata = policy_group_creator.get_policies_metadata()
     policy_merger = PolicyGroupMetadataMerger(policies_metadata=policies_metadata)
+    policy_merger.remove_policies_with_no_subelements()
     policy_merger.merge_by_subelements()
     ux2.policy_groups = policy_merger.get_merged_transformed_policy_groups()
 

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -57,6 +57,8 @@ from catalystwan.utils.config_migration.steps.constants import (
     WAN_VPN_MULTILINK,
 )
 from catalystwan.utils.config_migration.steps.transform import (
+    PolicyGroupMetadataCreator,
+    PolicyGroupMetadataMerger,
     convert_multi_parcel_feature_template,
     convert_single_parcel_feature_template,
     merge_parcels,
@@ -234,10 +236,12 @@ def get_version_info(session: ManagerSession) -> VersionInfo:
 def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult:
     transform_result = ConfigTransformResult()
     ux2 = UX2Config(version=ux1.version)
+    policy_group_creator = PolicyGroupMetadataCreator(ux1=ux1)
     subtemplates_mapping = defaultdict(set)
     used_feature_templates: Set[str] = set()
     # Create Feature Profiles and Config Group
     for dt in ux1.templates.device_templates:
+        policy_group_creator.create_and_store(dt)
         templates = dt.get_flattened_general_templates()
         # Create Feature Profiles
         fp_system_uuid = uuid4()
@@ -344,6 +348,7 @@ def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult
                 profiles=[],
             ),
         )
+
         # Add to UX2
         ux2.feature_profiles.append(transformed_fp_system)
         ux2.feature_profiles.append(transformed_fp_other)
@@ -351,6 +356,12 @@ def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult
         ux2.feature_profiles.append(transformed_fp_transport_and_management)
         ux2.feature_profiles.append(transformed_fp_cli)
         ux2.config_groups.append(transformed_cg)
+
+    # Add Policy Groups
+    policies_metadata = policy_group_creator.get_policies_metadata()
+    policy_merger = PolicyGroupMetadataMerger(policies_metadata=policies_metadata)
+    policy_merger.merge_by_subelements()
+    ux2.policy_groups = policy_merger.get_merged_transformed_policy_groups()
 
     cloud_credential_templates = ux1.templates.pop_cloud_credential_templates()
     # Sort by vpn feature templates to avoid any confilics with subtemplates


### PR DESCRIPTION
# Pull Request Summary:
Implement Policy Group aggregation and enhance feature profile handling
# Description of Changes:

### Feature Additions:

Implemented PolicyGroupEndpoints::update method
Created TestPolicyGroupAggregation for testing the new aggregation algorithm
Added ReferenceWithId field to AdvancedInspectionProfileAction
Implemented helper methods for ZoneBasedFWPolicySequence


### Bug Fixes:

UX2ConfigPusherReport::get_standalone_feature_profiles_by_ids now correctly collects profiles from the security_policies field
Added default values to UnifiedSecurityPolicy for type checking
Updated test_policy_profile_merge to verify correct UUIDs
Fixed SIG unit test for serialization issues


### Enhancements:

Developed an algorithm to merge policy groups with identical subelements
Modified PolicyGroupMetadataCreator to collect correct UUIDs from security policy
Created base pusher class that consumes prepared config to avoid code duplication 


### Refactoring:

Improved AdvancedInspectionProfileAction structure

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
