### PR TITLE
DeviceType has no name field

### DIFF
--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -122,7 +122,7 @@ class TemplatesAPI:
         return templates.dataseq(DeviceTemplateInfo)
 
     def attach(self, name: str, device: Device, timeout_seconds: int = 300, **kwargs):
-        template_type = self.get(DeviceTemplate).filter(name=name).single_or_default().config_type
+        template_type = self.get(DeviceTemplate).filter(template_name=name).single_or_default().config_type
         if template_type == TemplateType.CLI:
             return self._attach_cli(name, device, timeout_seconds=timeout_seconds, **kwargs)
 


### PR DESCRIPTION


# Pull Request summary:
```
2024-08-01 15:44:22,743 [INFO] Create CLI Template vm19 for device VManage(vm19)
2024-08-01 15:44:22,747 [DEBUG] Starting parallel test with 0 second delay: [<function device_to_vmanage_mode at 0x7f9d091ab790>, {'vm19': [VManage(vm19)]}, True]
2024-08-01 15:44:26,393 [DEBUG] Traceback (most recent call last):
  File "/scratch/jenkins/slave/workspace/CAT/main/execute_ts/vtest/tests/lib/executioner.py", line 303, in run_item
    result = item(*args, **kwargs)
  File "/scratch/jenkins/slave/workspace/CAT/main/execute_ts/vtest/tests/scripts/cases/setup.py", line 130, in device_to_vmanage_mode
    result = session.api.templates.attach(cli_template.template_name, device)
  File "/scratch/jenkins/.p3/lib/python3.8/site-packages/catalystwan/api/template_api.py", line 125, in attach
    template_type = self.get(DeviceTemplate).filter(name=name).single_or_default().config_type
AttributeError: 'NoneType' object has no attribute 'config_type'
```

# Description of changes:
After successful create of vm19 CLI template vi `/dataservice/template/device/cli/` with `templateName=vm19`, it attempts to attach it. In the process of attach, it first looks it up via `/dataservice/template/device?feature=all` and finds it:
```json
```
Actually it doesn't find it, so it looks like a vmanage bug

# Checklist:
- [ ] Make sure to run pre-commit before committing changes
- [ ] Make sure all checks have passed
- [ ] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [ ] Make sure you test the changes
