### PR TITLE
dev: config migration fixes for 20.12

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,6 +1,6 @@
 **THIS FILE WAS AUTO-GENERATED DO NOT EDIT**
 
-Generated for: catalystwan-0.34.0.dev1
+Generated for: catalystwan-0.34.0.dev2
 
 All URIs are relative to */dataservice*
 HTTP request | Supported Versions | Method | Payload Type | Return Type | Tenancy Mode

--- a/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/service/lan/ethernet.py
@@ -103,7 +103,10 @@ class VrrpIPv6(BaseModel):
 class VrrpIPv4(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
-    group_id: Union[Variable, Global[int]] = Field(serialization_alias="groupId", validation_alias="groupId")
+    group_id: Annotated[
+        Union[Variable, Global[int]],
+        VersionedField(versions="<=20.12", serialization_alias="group_id"),
+    ] = Field(serialization_alias="groupId", validation_alias=AliasChoices("groupId", "group_id"))
     priority: Union[Variable, Global[int], Default[int]] = Default[int](value=100)
     timer: Union[Variable, Global[int], Default[int]] = Default[int](value=1000)
     track_omp: Union[Global[bool], Default[bool]] = Field(
@@ -127,16 +130,25 @@ class VrrpIPv4(BaseModel):
         serialization_alias="trackingObject", validation_alias="trackingObject", default=None
     )
 
+    @model_serializer(mode="wrap", when_used="json")
+    def serialize(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> Dict[str, Any]:
+        return VersionedField.dump(self.model_fields, handler(self), info)
+
 
 class Trustsec(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, extra="forbid")
 
-    enable_sgt_propagation: Union[Global[bool], Default[bool]] = Field(
+    enable_sgt_propagation: Annotated[
+        Union[Global[bool], Default[bool]],
+        VersionedField(versions="<=20.12", serialization_alias="enableSGTPropogation"),
+    ] = Field(
         serialization_alias="enableSGTPropagation",
-        validation_alias="enableSGTPropagation",
+        validation_alias=AliasChoices("enableSGTPropagation", "enableSGTPropogation"),
         default=Default[bool](value=False),
     )
-    propagate: Optional[Union[Global[bool], Default[bool]]] = Default[bool](value=True)
+    propagate: Annotated[
+        Optional[Union[Global[bool], Default[bool]]], VersionedField(versions="<=20.12", forbidden=True)
+    ] = Default[bool](value=True)
     security_group_tag: Optional[Union[Global[int], Variable, Default[None]]] = Field(
         serialization_alias="securityGroupTag", validation_alias="securityGroupTag", default=None
     )

--- a/catalystwan/tests/config_migration/test_transform.py
+++ b/catalystwan/tests/config_migration/test_transform.py
@@ -1,5 +1,4 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
-# Copyright 2023 Cisco Systems, Inc. and its affiliates
 from typing import List, Optional, Set, TypeVar
 from uuid import UUID, uuid4
 
@@ -12,6 +11,7 @@ from catalystwan.models.configuration.config_migration import (
     UX1Config,
     UX1Policies,
     UX1Templates,
+    VersionInfo,
 )
 from catalystwan.models.templates import FeatureTemplateInformation
 from catalystwan.tests.config_migration.test_data import (
@@ -546,6 +546,7 @@ def test_when_localized_policy_with_qos_expect_application_priority_feature_prof
             policy_definitions=[qos_map_1, qos_map_2],
         )
     )
+    ux1_config.version = VersionInfo(platform="20.15")  # To include all items in the output)
     # Act
     ux2_config = transform(ux1_config).ux2_config
     # Find application priority feature profile
@@ -591,6 +592,7 @@ def test_policy_profile_merge():
 
     """
     ux1 = UX1Config()
+    ux1.version = VersionInfo(platform="20.15")  # To include all items in the output)
 
     sig_1_uuid = uuid4()
 

--- a/catalystwan/utils/config_migration/converters/policy/centralized_policy.py
+++ b/catalystwan/utils/config_migration/converters/policy/centralized_policy.py
@@ -15,6 +15,7 @@ from catalystwan.models.configuration.config_migration import (
     TransformedParcel,
     TransformedTopologyGroup,
     TransformHeader,
+    UnsupportedConversionItem,
     UX1Config,
     UX2Config,
 )
@@ -89,6 +90,7 @@ class CentralizedPolicyConverter:
         self.parcel_lookup: Dict[UUID, List[TransformedParcel]] = dict()
         self._create_parcel_by_policy_id_lookup()
         self.failed_items: List[FailedConversionItem] = list()
+        self.unsupported_items: List[UnsupportedConversionItem] = list()
 
     def _create_parcel_by_policy_id_lookup(self) -> None:
         for policy_definition in self.ux1.policies.policy_definitions:
@@ -218,7 +220,13 @@ class CentralizedPolicyConverter:
                 if dst_transformed_app_prio_parcels:
                     self.update_app_prio_profiles(centralized_policy, dst_transformed_app_prio_parcels)
             else:
-                problems.append("cli policy definition not supported")
+                self.unsupported_items.append(
+                    UnsupportedConversionItem(
+                        name=centralized_policy.policy_name,
+                        uuid=centralized_policy.policy_id,
+                        type=centralized_policy.policy_type,
+                    )
+                )
             if problems:
                 self.failed_items.append(
                     FailedConversionItem(policy=centralized_policy, exception_message="\n".join(problems))

--- a/catalystwan/utils/config_migration/converters/policy/policy_settings.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_settings.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 from uuid import UUID
 
+from packaging.version import Version
+
 from catalystwan.api.configuration_groups.parcel import as_optional_global
 from catalystwan.models.configuration.config_migration import ConvertResult, PolicyConvertContext
 from catalystwan.models.configuration.feature_profile.sdwan.application_priority.policy_settings import (
@@ -12,6 +14,14 @@ from catalystwan.models.policy.localized import LocalizedPolicyInfo
 def convert_localized_policy_settings(
     policy: LocalizedPolicyInfo, uuid: UUID, context: PolicyConvertContext
 ) -> ConvertResult[PolicySettingsParcel]:
+    if context.platform_version < Version("20.13"):
+        return ConvertResult(
+            status="unsupported",
+            info=[
+                f"Localized policy {policy.policy_name} is not supported on platform version {context.platform_version}"
+            ],
+        )
+
     if isinstance(policy.policy_definition, str):
         return ConvertResult(
             output=None,

--- a/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
+++ b/catalystwan/utils/config_migration/creators/localized_policy_pusher.py
@@ -185,6 +185,9 @@ class LocalizedPolicyPusher(Pusher):
             profile_type, profile_id, profile_name, transformed_parcels = profile_info
             self._progress(f"Updating {profile_name} profile with policy parcels", i + 1, len(profile_ids))
             for transformed_parcel in transformed_parcels:
+                if isinstance(transformed_parcel.parcel, RoutePolicyParcel):
+                    logger.warning("Route Policy is not supported in localized policy")
+                    continue
                 report = profile_reports[profile_id]
                 error_parcel = transformed_parcel.parcel
                 error_info: Union[ManagerErrorInfo, str, None] = None

--- a/catalystwan/utils/config_migration/reverters/config_reverter.py
+++ b/catalystwan/utils/config_migration/reverters/config_reverter.py
@@ -23,6 +23,14 @@ class UX2ConfigReverter:
                 all_deleted = False
                 logger.error(f"Error occured during deleting config group {cg_id}: {e}")
 
+        for i, pg in enumerate(rollback_info.policy_group_ids):
+            try:
+                self._session.endpoints.configuration.policy_group.delete(pg)
+                progress("Removing Policy Groups", i + 1, len(rollback_info.policy_group_ids))
+            except CatalystwanException as e:
+                all_deleted = False
+                logger.error(f"Error occured during deleting policy group {pg}: {e}")
+
         for i, tg_id in enumerate(rollback_info.topology_group_ids):
             try:
                 self._session.endpoints.configuration.topology_group.delete(tg_id)

--- a/catalystwan/utils/config_migration/steps/constants.py
+++ b/catalystwan/utils/config_migration/steps/constants.py
@@ -26,12 +26,15 @@ VPN_ADDITIONAL_TEMPLATES = [
     "bgp",
     "cisco_ospfv3",
     "cisco_ospf",
-    "ospf"
+    "ospf",
 ]
 
 NO_SUBSTITUTE_ERROR = "NO_SUBSTITUTE_ERROR"
 NO_SUBSTITUTE_VPN_MANAGEMENT_SVI = (
     "NO_SUBSTITUTE_ERROR: UX1.0 -> We can attach SVI to vpn 512, UX2.0 -> There is no SVI parcel for vpn 512"
+)
+NO_SUBSTITUTE_VPN_TRANSPORT_SVI = (
+    "NO_SUBSTITUTE_ERROR: UX1.0 -> We can attach SVI to vpn 0, UX2.0 -> There is no SVI parcel for vpn 0"
 )
 
 MANAGEMENT_VPN_ETHERNET = "management/vpn/interface/ethernet"
@@ -75,7 +78,7 @@ VPN_TEMPLATE_MAPPINGS: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {
             "vpn-vedge-interface-gre": WAN_VPN_GRE,
             "cisco_vpn_interface_gre": WAN_VPN_GRE,
             "cisco_vpn_interface_ipsec": WAN_VPN_IPSEC,
-            "vpn-interface-svi": WAN_VPN_SVI,
+            "vpn-interface-svi": NO_SUBSTITUTE_VPN_TRANSPORT_SVI,
             "cisco_vpn_interface": WAN_VPN_ETHERNET,
             "vpn-vsmart-interface": WAN_VPN_ETHERNET,
             "vpn-vedge-interface": WAN_VPN_ETHERNET,

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -455,8 +455,8 @@ def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult
         if settings_status == "unsupported":
             transform_result.add_unsupported_item(
                 name=f"{localized_policy.policy_name} Settings",
-                uuid=policy_definition.definition_id,
-                type=policy_definition.type,
+                uuid=localized_policy.policy_id,
+                type=localized_policy.policy_type,
             )
         elif settings_status == "failed":
             transform_result.add_failed_conversion_parcel(

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -530,6 +530,7 @@ def transform(ux1: UX1Config, add_suffix: bool = False) -> ConfigTransformResult
     centralized_policy_converter = CentralizedPolicyConverter(ux1=ux1, context=policy_context, ux2=ux2)
     centralized_policy_converter.update_groups_and_profiles()
     transform_result.failed_items.extend(centralized_policy_converter.failed_items)
+    transform_result.unsupported_items.extend(centralized_policy_converter.unsupported_items)
 
     # Add additional objects emmited by the conversion
     ux2.thread_grid_api = policy_context.threat_grid_api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.34.0dev1"
+version = "0.34.0dev2"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
config migration fixes for 20.12
- Fix ethernet model
- Add rollbacking policy groups
- Mark policy settings as unsupported for 20.12
- Dont create SVI interface for transport and management feature profile

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
