### PR TITLE
fix: vsmart template activate/deactivate response validation

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,6 +1,6 @@
 **THIS FILE WAS AUTO-GENERATED DO NOT EDIT**
 
-Generated for: catalystwan-0.34.0
+Generated for: catalystwan-0.34.1
 
 All URIs are relative to */dataservice*
 HTTP request | Supported Versions | Method | Payload Type | Return Type | Tenancy Mode

--- a/catalystwan/endpoints/configuration/policy/vsmart_template.py
+++ b/catalystwan/endpoints/configuration/policy/vsmart_template.py
@@ -26,7 +26,7 @@ class AutoConfirm(BaseModel):
 
 
 class ActivateDeactivateTaskId(BaseModel):
-    id: UUID
+    id: str
 
 
 class ConfigurationVSmartTemplatePolicy(APIEndpoints):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.34.0"
+version = "0.34.1"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
activate/deactivate id string returned by server is not UUID (contains custom prefix)

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
