### PR TITLE
Addition of strip to get rid of unwanted whitespaces, plus option to …

### DIFF
--- a/catalystwan/api/templates/cli_template.py
+++ b/catalystwan/api/templates/cli_template.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from difflib import Differ
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from attr import define  # type: ignore
 from ciscoconfparse import CiscoConfParse  # type: ignore
@@ -126,6 +126,7 @@ class CLITemplate:
         second: CiscoConfParse,
         full: bool = False,
         debug: bool = False,
+        ignored_lines: List[str] = [],
     ) -> str:
         """
 
@@ -162,8 +163,11 @@ class CLITemplate:
             auth-port 151
         exit
         """
-        first_n = list(map(lambda x: x + "\n", first.ioscfg))
-        second_n = list(map(lambda x: x + "\n", second.ioscfg))
+        for line in ignored_lines:
+            first.delete_lines(line)
+            second.delete_lines(line)
+        first_n = list(map(lambda x: x.strip() + "\n", first.ioscfg))
+        second_n = list(map(lambda x: x.strip() + "\n", second.ioscfg))
         compare = list(Differ().compare(first_n, second_n))
         if not full:
             compare = [x for x in compare if x[0] in ["?", "-", "+"]]
@@ -177,6 +181,7 @@ class CLITemplate:
         template: CiscoConfParse,
         device: Device,
         debug: bool = False,
+        ignored_lines: List[str] = [],
     ) -> str:
         """The comparison of the config with the one running on the machine.
 
@@ -216,4 +221,4 @@ class CLITemplate:
         .
         """
         running_config = self.load_running(session, device)
-        return self.compare_template(running_config, template, debug)
+        return self.compare_template(running_config, template, debug=debug, ignored_lines=ignored_lines)


### PR DESCRIPTION
…ignore certain lines when comparing configs

# Pull Request summary:
PR addresses two matters within CLI_Template.compare_template():
1. White-spaces before config statements, that are sometimes present when pulling cEdge/vEdge running config from vManage. Those white-spaces can make comparision faulty, even though all compared configs statements are identical
2. Adds possibility to ignore certain config statements inside CLI_Template.compare_template().

# Description of changes:
1. Applied str.strip() to each compared config line to make sure, that any whitespaces do not fail the result of comparison.
2. Used CiscoConfParse.delete_lines() to get rid of unnecessary configs line from comparison. 

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
