### PR TITLE
auth: refactor

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,6 +1,6 @@
 **THIS FILE WAS AUTO-GENERATED DO NOT EDIT**
 
-Generated for: catalystwan-0.35.3
+Generated for: catalystwan-0.35.4
 
 All URIs are relative to */dataservice*
 HTTP request | Supported Versions | Method | Payload Type | Return Type | Tenancy Mode

--- a/catalystwan/apigw_auth.py
+++ b/catalystwan/apigw_auth.py
@@ -32,11 +32,14 @@ class ApiGwAuth(AuthBase, AuthProtocol):
     2. Use the token in the Authorization header for subsequent requests.
     """
 
-    def __init__(self, login: ApiGwLogin, logger: Optional[logging.Logger] = None, verify=False):
+    def __init__(self, login: ApiGwLogin, logger: Optional[logging.Logger] = None, verify: bool = False):
         self.login = login
         self.token = ""
         self.logger = logger or logging.getLogger(__name__)
         self.verify = verify
+
+    def __str__(self) -> str:
+        return f"ApiGatewayAuth(mode={self.login.mode})"
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
         self.handle_auth(request)
@@ -61,7 +64,9 @@ class ApiGwAuth(AuthBase, AuthProtocol):
         request.headers.update(header)
 
     @staticmethod
-    def get_token(base_url: str, apigw_login: ApiGwLogin, logger: Optional[logging.Logger] = None, verify=False) -> str:
+    def get_token(
+        base_url: str, apigw_login: ApiGwLogin, logger: Optional[logging.Logger] = None, verify: bool = False
+    ) -> str:
         try:
             response = post(
                 url=f"{base_url}/apigw/login",
@@ -83,9 +88,6 @@ class ApiGwAuth(AuthBase, AuthProtocol):
             if not token or not isinstance(token, str):
                 raise CatalystwanException("Failed to get bearer token")
         return token
-
-    def __str__(self) -> str:
-        return f"ApiGatewayAuth(mode={self.login.mode})"
 
     def logout(self, client: APIEndpointClient) -> None:
         return None

--- a/catalystwan/response.py
+++ b/catalystwan/response.py
@@ -109,7 +109,7 @@ def auth_response_debug(response: Response, title: str = "Auth") -> str:
     if environ.get("catalystwan_auth_trace") is not None:
         return response_history_debug(response, None)
     return ", ".join(
-        [f"{title}: {r.request.method} {r.request.url} <{r.status_code}>" for r in response.history + [response]]
+        [title] + [f"{r.request.method} {r.request.url} <{r.status_code}>" for r in response.history + [response]]
     )
 
 

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -242,7 +242,6 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         self.verify = False
         self.headers.update({"User-Agent": USER_AGENT})
         self._auth = auth
-        self._auth.cookies = self.cookies
         self._platform_version: str = ""
         self._api_version: Version = NullVersion  # type: ignore
         self.restart_timeout: int = 1200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.35.3"
+version = "0.35.4"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
vManageAuth refactor

# Description of changes:
- fix `409` when `VSessionId` was not properly refreshed after `JSESSIONID` updated
- fix infinite auth loop when `vAnalytics` enabled
- `VSessionId` flow for `provider-as-tenant` is now separate `AuthBase` class instead part of `login()` method

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
