### PR TITLE
Multithreading Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ from catalystwan.request_limiter import RequestLimiter
 
 auth = vManageAuth(username="username", password="password")
 limiter = RequestLimiter(max_requests=30)
-manager = ManagerSession(base_url="https://url:port", auth=auth)
+manager = ManagerSession(base_url="https://url:port", auth=auth, request_limiter=limiter)
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -430,8 +430,6 @@ limiter = RequestLimiter(max_requests=60)
 
 
 def simple_request(auth, device_id):
-    logger = logging.getLogger(__name__)
-    logger.setLevel(level=10)
     with create_manager_session(
         url="url",
         username="username",

--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ def print_devices(manager: ManagerSession):
 
 if __name__ =="__main__":
 
+    # 1. Create shared authentication handler for user session
     auth = vManageAuth(username="username", password="password")
+    # 2. Configure session with base url and attach authentication handler
     manager = ManagerSession(base_url="https://url:port", auth=auth)
 
+    # 3. Make sure each thread gets own copy of ManagerSession object
     t1 = Thread(target=print_devices, args=(manager,))
     t2 = Thread(target=print_devices, args=(copy(manager),))
     t3 = Thread(target=print_devices, args=(copy(manager),))

--- a/README.md
+++ b/README.md
@@ -439,7 +439,6 @@ def simple_request(auth, device_id):
         auth=auth,
         request_lmiter=limiter
     ) as client:
-    # Get current credentials
         admin_tech_file = client.api.admin_tech.generate(device_id)
         return admin_tech_file
     

--- a/README.md
+++ b/README.md
@@ -125,6 +125,51 @@ with create_apigw_session(
 ```
 </details>
 
+<details>
+    <summary> <b>Threading</b> <i>(click to expand)</i></summary>
+
+```python
+from threading import Thread
+from catalystwan.session import ManagerSession
+from catalystwan.vmanage_auth import vManageAuth
+from copy import copy
+
+def print_devices(manager: ManagerSession):
+    # using context manager (recommended)
+    with manager.login() as session:
+        print(session.api.devices.get())
+
+if __name__ =="__main__":
+
+    auth = vManageAuth(username="username", password="password")
+    manager = ManagerSession(base_url="https://url:port", auth=auth)
+
+    t1 = Thread(target=print_devices, args=(manager,))
+    t2 = Thread(target=print_devices, args=(copy(manager),))
+    t3 = Thread(target=print_devices, args=(copy(manager),))
+
+    t1.start()
+    t2.start()
+    t3.start()
+
+    t1.join()
+    t2.join()
+    t3.join()
+
+    print("Done!")
+```
+Threading can be achieved by using a shared auth object with sessions in each thread. As `ManagerSession` is not guaranteed to be thread-safe, it is recommended to create one session per thread. `ManagerSession` also comes in with a default `RequestLimiter`, which limits the number of concurrent requests to 50. It keeps `ManagerSession` from overloading the server and avoids HTTP 503 and HTTP 429 errors.
+If you wish to modify the limit, you can pass a modified `RequestLimiter` to `ManagerSession`:
+```python
+from catalystwan.session import ManagerSession
+from catalystwan.vmanage_auth import vManageAuth
+from catalystwan.request_limiter import RequestLimiter
+
+auth = vManageAuth(username="username", password="password")
+limiter = RequestLimiter(max_requests=30)
+manager = ManagerSession(base_url="https://url:port", auth=auth)
+```
+</details>
 
 ## API usage examples
 All examples below assumes `session` variable contains logged-in [Manager Session](#Manager-Session) instance.
@@ -413,42 +458,6 @@ migrate_task.wait_for_completed()
 ```
 </details>
 
-<details>
-    <summary> <b>Threading</b> <i>(click to expand)</i></summary>
-
-```python
-from concurrent.futures import ThreadPoolExecutor
-
-from catalystwan.request_limiter import RequestLimiter
-from catalystwan.session import create_manager_session
-from catalystwan.vmanage_auth import create_vmanage_auth
-
-
-device_ids = [...]
-auth = create_vmanage_auth("username", "password")
-limiter = RequestLimiter(max_requests=60)
-
-
-def simple_request(auth, device_id):
-    with create_manager_session(
-        url="url",
-        username="username",
-        password="password",
-        auth=auth,
-        request_lmiter=limiter
-    ) as client:
-        admin_tech_file = client.api.admin_tech.generate(device_id)
-        return admin_tech_file
-    
-with ThreadPoolExecutor(len(device_ids)) as executor:
-    results = [executor.submit(simple_request, auth, device_id) for device_id in device_ids]
-
-
-admin_tech_files = [result.result() for result in results]
-```
-Threading can be achieved by using a shared auth object with sessions in each thread. As `ManagerSession` is not guaranteed to be thread-safe, it is recommended to create one session per thread.
-`RequestLimiter` puts a limit on concurrent requests. It is not required, but highly recommended. Sending too many concurrent requests will result in either HTTP 503 or HTTP 429 errors.
-</details>
 
 ### Note:
 To remove `InsecureRequestWarning`, you can include in your scripts (warning is suppressed when `catalystwan_devel` environment variable is set):

--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -2,7 +2,8 @@
 
 from typing import Optional, Protocol, Type, TypeVar
 
-from packaging.version import Version  # type: ignore
+from packaging.version import Version
+from requests import PreparedRequest  # type: ignore
 
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.session_type import SessionType
@@ -67,4 +68,13 @@ class AuthProtocol(Protocol):
         ...
 
     def clear(self) -> None:
+        ...
+
+    def clear_sync(self, last_request: Optional[PreparedRequest]) -> None:
+        ...
+
+    def register_session(self) -> None:
+        ...
+    
+    def unregister_session(self) -> None:
         ...

--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Protocol, Type, TypeVar
 
-from packaging.version import Version # type: ignore
+from packaging.version import Version  # type: ignore
 from requests import PreparedRequest
 
 from catalystwan.typed_list import DataSequence
@@ -72,6 +72,6 @@ class AuthProtocol(Protocol):
 
     def increase_session_count(self) -> None:
         ...
-    
+
     def decrease_session_count(self) -> None:
         ...

--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -2,8 +2,8 @@
 
 from typing import Optional, Protocol, Type, TypeVar
 
-from packaging.version import Version
-from requests import PreparedRequest  # type: ignore
+from packaging.version import Version # type: ignore
+from requests import PreparedRequest
 
 from catalystwan.typed_list import DataSequence
 from catalystwan.utils.session_type import SessionType

--- a/catalystwan/abstractions.py
+++ b/catalystwan/abstractions.py
@@ -67,14 +67,11 @@ class AuthProtocol(Protocol):
     def logout(self, client: APIEndpointClient) -> None:
         ...
 
-    def clear(self) -> None:
+    def clear(self, last_request: Optional[PreparedRequest]) -> None:
         ...
 
-    def clear_sync(self, last_request: Optional[PreparedRequest]) -> None:
-        ...
-
-    def register_session(self) -> None:
+    def increase_session_count(self) -> None:
         ...
     
-    def unregister_session(self) -> None:
+    def decrease_session_count(self) -> None:
         ...

--- a/catalystwan/apigw_auth.py
+++ b/catalystwan/apigw_auth.py
@@ -38,7 +38,7 @@ class ApiGwAuth(AuthBase, AuthProtocol):
         self.token = ""
         self.logger = logger or logging.getLogger(__name__)
         self.verify = verify
-        self.registered_sessions: int = 0
+        self.session_count: int = 0
         self.lock: RLock = RLock()
 
     def __str__(self) -> str:
@@ -102,11 +102,11 @@ class ApiGwAuth(AuthBase, AuthProtocol):
 
     def increase_session_count(self) -> None:
         with self.lock:
-            self.registered_sessions += 1
+            self.session_count += 1
 
     def decrease_session_count(self) -> None:
         with self.lock:
-            self.registered_sessions -= 1
+            self.session_count -= 1
 
     def clear(self, last_request: Optional[PreparedRequest]) -> None:
         with self.lock:

--- a/catalystwan/apigw_auth.py
+++ b/catalystwan/apigw_auth.py
@@ -96,19 +96,19 @@ class ApiGwAuth(AuthBase, AuthProtocol):
     def logout(self, client: APIEndpointClient) -> None:
         return None
 
-    def clear(self) -> None:
+    def _clear(self) -> None:
         with self.lock:
             self.token = ""
 
-    def register_session(self) -> None:
+    def increase_session_count(self) -> None:
         with self.lock:
             self.registered_sessions += 1
 
-    def unregister_session(self) -> None:
+    def decrease_session_count(self) -> None:
         with self.lock:
             self.registered_sessions -= 1
 
-    def clear_sync(self, last_request: Optional[PreparedRequest]) -> None:
+    def clear(self, last_request: Optional[PreparedRequest]) -> None:
         with self.lock:
             # extract previously used jsessionid
             if last_request is None:
@@ -118,7 +118,7 @@ class ApiGwAuth(AuthBase, AuthProtocol):
 
             if self.token == "" or f"Bearer {self.token}" == token:
                 # used auth was up-to-date, clear state
-                return self.clear()
+                return self._clear()
             else:
                 # used auth was out-of-date, repeat the request with a new one
                 return

--- a/catalystwan/request_limiter.py
+++ b/catalystwan/request_limiter.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
 from threading import Semaphore
-from typing import Callable
-
-from catalystwan.response import ManagerResponse
 
 
-class RequestLimiter:
-    def __init__(self, max_requests: int = 60):
-        self.max_requests: int = max_requests
-        self._semaphore = Semaphore(value=self.max_requests)
+class RequestLimiter(AbstractContextManager):
+    def __init__(self, max_requests: int = 49):
+        self._max_requests: int = max_requests
+        self._semaphore: Semaphore = Semaphore(value=self._max_requests)
+    
+    def __enter__(self) -> RequestLimiter:
+        self._semaphore.acquire()
+        return self
 
-    def send_request(self, delayed_request: Callable[[], ManagerResponse]) -> ManagerResponse:
-        with self._semaphore:
-            result = delayed_request()
-            return result
+    def __exit__(self, *exc_info) -> None:
+        self._semaphore.release()
+        return

--- a/catalystwan/request_limiter.py
+++ b/catalystwan/request_limiter.py
@@ -1,0 +1,15 @@
+from threading import Semaphore
+from typing import Callable
+
+from catalystwan.response import ManagerResponse
+
+
+class RequestLimiter:
+    def __init__(self, max_requests: int = 60):
+        self.max_requests: int = max_requests
+        self._semaphore = Semaphore(value=self.max_requests)
+
+    def send_request(self, delayed_request: Callable[[], ManagerResponse]) -> ManagerResponse:
+        with self._semaphore:
+            result = delayed_request()
+            return result

--- a/catalystwan/request_limiter.py
+++ b/catalystwan/request_limiter.py
@@ -8,7 +8,7 @@ class RequestLimiter(AbstractContextManager):
     def __init__(self, max_requests: int = 49):
         self._max_requests: int = max_requests
         self._semaphore: Semaphore = Semaphore(value=self._max_requests)
-    
+
     def __enter__(self) -> RequestLimiter:
         self._semaphore.acquire()
         return self

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -15,7 +15,6 @@ from requests import PreparedRequest, Request, Response, Session, get, head
 from requests.exceptions import ConnectionError, HTTPError, RequestException
 
 from catalystwan import USER_AGENT
-from catalystwan.abstractions import AuthProtocol
 from catalystwan.apigw_auth import ApiGwAuth, ApiGwLogin, LoginMode
 from catalystwan.endpoints import APIEndpointClient
 from catalystwan.endpoints.client import AboutInfo, ServerInfo
@@ -445,7 +444,10 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
             raise ManagerRequestException(*exception.args, request=exception.request, response=exception.response)
 
         self._last_request = response.request
-        if response.jsessionid_expired and self.state in [ManagerSessionState.OPERATIVE, ManagerSessionState.LOGIN_IN_PROGRESS]:
+        if response.jsessionid_expired and self.state in [
+            ManagerSessionState.OPERATIVE,
+            ManagerSessionState.LOGIN_IN_PROGRESS,
+        ]:
             # detected expired auth during login, resync
             if self.state == ManagerSessionState.LOGIN_IN_PROGRESS:
                 self.state = ManagerSessionState.AUTH_SYNC
@@ -454,7 +456,10 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
                 self.state = ManagerSessionState.LOGIN
             return self.request(method, url, *args, **_kwargs)
 
-        if response.api_gw_unauthorized and self.state in [ManagerSessionState.OPERATIVE, ManagerSessionState.LOGIN_IN_PROGRESS]:
+        if response.api_gw_unauthorized and self.state in [
+            ManagerSessionState.OPERATIVE,
+            ManagerSessionState.LOGIN_IN_PROGRESS,
+        ]:
             # detected expired auth during login, resync
             if self.state == ManagerSessionState.LOGIN_IN_PROGRESS:
                 self.state = ManagerSessionState.AUTH_SYNC

--- a/catalystwan/vmanage_auth.py
+++ b/catalystwan/vmanage_auth.py
@@ -112,10 +112,7 @@ class vManageAuth(AuthBase, AuthProtocol):
         response: Response = post(url=url, headers=headers, data=security_payload, verify=self.verify)
         self.sync_cookies(response.cookies)
         self.logger.debug(auth_response_debug(response, str(self)))
-        if response.status_code != 200:
-            print("OLABOGA")
         if response.text != "" or not isinstance(self.jsessionid, str) or self.jsessionid == "":
-            print("NEIN!!!")
             raise UnauthorizedAccessError(self.username, self.password)
         return self.jsessionid
 
@@ -131,7 +128,6 @@ class vManageAuth(AuthBase, AuthProtocol):
         self.sync_cookies(response.cookies)
         self.logger.debug(auth_response_debug(response, str(self)))
         if response.status_code != 200 or "<html>" in response.text:
-            print("MAMMA MIA!")
             raise CatalystwanException("Failed to get XSRF token")
         return response.text
 
@@ -174,7 +170,6 @@ class vManageAuth(AuthBase, AuthProtocol):
     def decrease_session_count(self) -> None:
         with self.lock:
             self.session_count -= 1
-            print(f"Remaining: {self.session_count}")
 
     def clear(self, last_request: Optional[PreparedRequest]) -> None:
         with self.lock:

--- a/catalystwan/vmanage_auth.py
+++ b/catalystwan/vmanage_auth.py
@@ -150,9 +150,13 @@ class vManageAuth(AuthBase, AuthProtocol):
             else:
                 headers = {"x-xsrf-token": self.xsrftoken, "User-Agent": USER_AGENT}
                 if version >= Version("20.12"):
-                    response = post(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
+                    response = post(
+                        f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify
+                    )
                 else:
-                    response = get(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
+                    response = get(
+                        f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify
+                    )
                 self.logger.debug(auth_response_debug(response, str(self)))
                 if response.status_code != 200:
                     self.logger.error("Unsuccessfull logout")

--- a/catalystwan/vmanage_auth.py
+++ b/catalystwan/vmanage_auth.py
@@ -2,6 +2,7 @@
 
 import logging
 from http.cookies import SimpleCookie
+from threading import RLock
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -78,14 +79,17 @@ class vManageAuth(AuthBase, AuthProtocol):
         self.logger = logger or logging.getLogger(__name__)
         self.cookies: RequestsCookieJar = RequestsCookieJar()
         self._base_url: str = ""
+        self.registered_sessions: int = 0
+        self.lock: RLock = RLock()
 
     def __str__(self) -> str:
         return f"vManageAuth(username={self.username})"
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
-        self.handle_auth(request)
-        update_headers(request, self.jsessionid, self.xsrftoken)
-        return request
+        with self.lock:
+            self.handle_auth(request)
+            update_headers(request, self.jsessionid, self.xsrftoken)
+            return request
 
     def sync_cookies(self, cookies: RequestsCookieJar) -> None:
         self.cookies = merge_cookies(self.cookies, cookies)
@@ -133,24 +137,61 @@ class vManageAuth(AuthBase, AuthProtocol):
         self.xsrftoken = self.get_xsrftoken()
 
     def logout(self, client: APIEndpointClient) -> None:
-        if isinstance((version := client.api_version), NullVersion):
-            self.logger.warning("Cannot perform logout without known api version.")
-        elif self._base_url is None:
-            self.logger.warning("Cannot perform logout without known base url")
-        else:
-            headers = {"x-xsrf-token": self.xsrftoken, "User-Agent": USER_AGENT}
-            if version >= Version("20.12"):
-                response = post(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
+        with self.lock:
+            if self.registered_sessions > 1:
+                # Other sessions still use the auth, unregister and return
+                self.unregister_session()
+                return
+
+            # last session using the auth, logout
+            if isinstance((version := client.api_version), NullVersion):
+                self.logger.warning("Cannot perform logout without known api version.")
+            elif self._base_url is None:
+                self.logger.warning("Cannot perform logout without known base url")
             else:
-                response = get(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
-            self.logger.debug(auth_response_debug(response, str(self)))
-            if response.status_code != 200:
-                self.logger.error("Unsuccessfull logout")
-        self.clear()
+                headers = {"x-xsrf-token": self.xsrftoken, "User-Agent": USER_AGENT}
+                if version >= Version("20.12"):
+                    response = post(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
+                else:
+                    response = get(f"{self._base_url}/logout", headers=headers, cookies=self.cookies, verify=self.verify)
+                self.logger.debug(auth_response_debug(response, str(self)))
+                if response.status_code != 200:
+                    self.logger.error("Unsuccessfull logout")
+            self.clear()
+            self.unregister_session()
 
     def clear(self) -> None:
-        self.cookies.clear_session_cookies()
-        self.xsrftoken = None
+        with self.lock:
+            self.cookies.clear_session_cookies()
+            self.xsrftoken = None
+
+    def register_session(self) -> None:
+        with self.lock:
+            self.registered_sessions += 1
+
+    def unregister_session(self) -> None:
+        with self.lock:
+            self.registered_sessions -= 1
+
+    def clear_sync(self, last_request: Optional[PreparedRequest]) -> None:
+        with self.lock:
+            # extract previously used jsessionid
+            if last_request is None:
+                jsessionid = None
+            else:
+                cookie: SimpleCookie = SimpleCookie()
+                cookie.load(last_request.headers.get("Cookie", ""))
+                try:
+                    jsessionid = cookie["JSESSIONID"].value
+                except KeyError:
+                    jsessionid = None
+
+            if self.jsessionid is None or self.jsessionid == jsessionid:
+                # used auth was up-to-date, clear state
+                return self.clear()
+            else:
+                # used auth was out-of-date, repeat the request with a new one
+                return
 
 
 class vSessionAuth(vManageAuth):
@@ -170,9 +211,10 @@ class vSessionAuth(vManageAuth):
         return f"vSessionAuth(username={self.username},subdomain={self.subdomain})"  # noqa: E231
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
-        self.handle_auth(request)
-        update_headers(request, self.jsessionid, self.xsrftoken, self.vsessionid)
-        return request
+        with self.lock:
+            self.handle_auth(request)
+            update_headers(request, self.jsessionid, self.xsrftoken, self.vsessionid)
+            return request
 
     def authenticate(self, request: PreparedRequest):
         super().authenticate(request)
@@ -210,8 +252,9 @@ class vSessionAuth(vManageAuth):
         return response.json()["VSessionId"]
 
     def clear(self) -> None:
-        super().clear()
-        self.vsessionid = None
+        with self.lock:
+            super().clear()
+            self.vsessionid = None
 
 
 def create_vmanage_auth(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.35.6"
+version = "0.35.7"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.35.7"
+version = "0.36.0"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
Adds support for multithreading authentication, which allows for concurrent requests using the same auth.

# Usage example:
```python
from threading import Thread
from catalystwan.session import ManagerSession
from catalystwan.vmanage_auth import vManageAuth
from copy import copy

def print_devices(manager: ManagerSession):
    # using context manager (recommended)
    with manager.login() as session:
        print(session.api.devices.get())

if __name__ =="__main__":

    # 1. Create shared authentication handler for user session
    auth = vManageAuth(username="username", password="password")
    # 2. Configure session with base url and attach authentication handler
    manager = ManagerSession(base_url="https://url:port", auth=auth)
    # 3. Make sure each thread gets own copy of ManagerSession object
    t1 = Thread(target=print_devices, args=(manager,))
    t2 = Thread(target=print_devices, args=(copy(manager),))
    t3 = Thread(target=print_devices, args=(copy(manager),))

    t1.start()
    t2.start()
    t3.start()

    t1.join()
    t2.join()
    t3.join()

    print("Done!")
```

# Checklist:
- [ ] Make sure to run pre-commit before committing changes
- [ ] Make sure all checks have passed
- [ ] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [ ] Make sure you test the changes
