### PR TITLE
fix get_connected_devices endpoint

### DIFF
--- a/catalystwan/endpoints/cluster_management.py
+++ b/catalystwan/endpoints/cluster_management.py
@@ -2,7 +2,6 @@
 
 # mypy: disable-error-code="empty-body"
 from typing import Dict, Literal, Optional
-from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -28,7 +27,7 @@ class VManageDetails(BaseModel):
 
 class ConnectedDevice(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    uuid: UUID
+    uuid: str
     device_id: str = Field(serialization_alias="deviceId", validation_alias="deviceId")
 
 


### PR DESCRIPTION
# Pull Request summary:
Fix `get_connected_devices` endpoint

# Description of changes:
`get_connected_devices` endpoint response can contain vEdge devices. Those devices can have a uuid, that does not fit the standard hexadecimal uuid format, i.e.:
`C8K-220291CC-2003-3CDA-FDDA-F24D9E7B4B89`
This leads to SDK throwing a ValueError.
This PR changes UUID to basic string to avoid that.

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
