### PR TITLE
add support for tenant level user to make API calls for mtt aaa

### DIFF
--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -71,7 +71,7 @@ class TenantAaaAPI:
         :param aaa:
         :return:
         """
-        logger.debug("AAA config {self.tenant_org_name}")
+        logger.debug(f"AAA config {self.tenant_org_name}")
         tenant_aaa = self.session.get_data(self.url_path)
         # return tenant_aaa
         return create_dataclass(TenantAAA, tenant_aaa)
@@ -83,8 +83,8 @@ class TenantAaaAPI:
         :return:
         """
         if not self.aaa_exists():
-            raise AAAConfigNotPresent("No AAA config present for Tenant {self.tenant_org_name}")
-        logger.debug("Delete AAA config on tenant {self.tenant_org_name}")
+            raise AAAConfigNotPresent(f"No AAA config present for Tenant {self.tenant_org_name}")
+        logger.debug(f"Delete AAA config on tenant {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     @status_ok
@@ -124,7 +124,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug("Add RADIUS config {self.tenant_org_name}")
+        logger.debug(f"Add RADIUS config {self.tenant_org_name}")
         data = asdict(radius_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -135,7 +135,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug("Update RADIUS config {self.tenant_org_name}")
+        logger.debug(f"Update RADIUS config {self.tenant_org_name}")
         data = asdict(radius_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -146,7 +146,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return: True|False
         """
-        logger.debug("Delete RADIUS config {self.tenant_org_name}")
+        logger.debug(f"Delete RADIUS config {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     def get_radius(self) -> TenantRadiusServer:
@@ -154,7 +154,7 @@ class TenantRadiusAPI:
         Retrieve Radius server
         :return: TenantRadiusServer
         """
-        logger.debug("RADIUS config {self.tenant_org_name}")
+        logger.debug(f"RADIUS config {self.tenant_org_name}")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
@@ -186,7 +186,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug("TACACS config {self.tenant_org_name}")
+        logger.debug(f"TACACS config {self.tenant_org_name}")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -197,7 +197,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug("Update TACACS config {self.tenant_org_name}")
+        logger.debug(f"Update TACACS config {self.tenant_org_name}")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -208,7 +208,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return: True|False
         """
-        logger.debug("Delete TACACS config {self.tenant_org_name}")
+        logger.debug(f"Delete TACACS config {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     def get_tacacs(self) -> TenantTacacsServer:
@@ -216,6 +216,6 @@ class TenantTacacsAPI:
         Retrieves Tacacs server
         :return: TenantTacacsServer
         """
-        logger.debug("TACACS config {self.tenant_org_name}")
+        logger.debug(f"TACACS config {self.tenant_org_name}")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantTacacsServer, data)

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -101,14 +101,6 @@ class TenantRadiusAPI:
     def __str__(self) -> str:
         return str(self.session)
 
-    @property
-    def tenant_org_name(self):
-        """
-        Get the tenant org name
-        :return:
-        """
-        return self.endpoints.configuration_settings.get_organizations().first().org
-
     @status_ok
     def add_radius(self, radius_server: TenantRadiusServer):
         """
@@ -162,14 +154,6 @@ class TenantTacacsAPI:
 
     def __str__(self) -> str:
         return str(self.session)
-
-    @property
-    def tenant_org_name(self):
-        """
-        Get the tenant org name
-        :return:
-        """
-        return self.endpoints.configuration_settings.get_organizations().first().org
 
     @status_ok
     def add_tacacs(self, tacacs_server: TenantTacacsServer):

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -42,14 +42,6 @@ class TenantAaaAPI:
     def aaa_exists(self) -> bool:
         return True if self.session.get_data(self.url_path) else False
 
-    @property
-    def tenant_org_name(self):
-        """
-        Get the tenant org name
-        :return:
-        """
-        return self.endpoints.configuration_settings.get_organizations().first().org
-
     @status_ok
     def add_aaa(self, tenant_aaa: TenantAAA):
         """ "
@@ -71,7 +63,7 @@ class TenantAaaAPI:
         :param aaa:
         :return:
         """
-        logger.debug(f"AAA config {self.tenant_org_name}")
+        logger.debug("AAA config")
         tenant_aaa = self.session.get_data(self.url_path)
         # return tenant_aaa
         return create_dataclass(TenantAAA, tenant_aaa)
@@ -83,8 +75,8 @@ class TenantAaaAPI:
         :return:
         """
         if not self.aaa_exists():
-            raise AAAConfigNotPresent(f"No AAA config present for Tenant {self.tenant_org_name}")
-        logger.debug(f"Delete AAA config on tenant {self.tenant_org_name}")
+            raise AAAConfigNotPresent("No AAA config present for Tenant")
+        logger.debug("Delete AAA config on tenant")
         return self.session.delete(self.url_path)
 
     @status_ok
@@ -124,7 +116,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug(f"Add RADIUS config {self.tenant_org_name}")
+        logger.debug("Add RADIUS config")
         data = asdict(radius_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -135,7 +127,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug(f"Update RADIUS config {self.tenant_org_name}")
+        logger.debug("Update RADIUS config")
         data = asdict(radius_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -146,7 +138,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return: True|False
         """
-        logger.debug(f"Delete RADIUS config {self.tenant_org_name}")
+        logger.debug("Delete RADIUS config")
         return self.session.delete(self.url_path)
 
     def get_radius(self) -> TenantRadiusServer:
@@ -154,7 +146,7 @@ class TenantRadiusAPI:
         Retrieve Radius server
         :return: TenantRadiusServer
         """
-        logger.debug(f"RADIUS config {self.tenant_org_name}")
+        logger.debug("RADIUS config")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
@@ -186,7 +178,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug(f"TACACS config {self.tenant_org_name}")
+        logger.debug("TACACS config")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -197,7 +189,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug(f"Update TACACS config {self.tenant_org_name}")
+        logger.debug("Update TACACS config")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -208,7 +200,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return: True|False
         """
-        logger.debug(f"Delete TACACS config {self.tenant_org_name}")
+        logger.debug("Delete TACACS config")
         return self.session.delete(self.url_path)
 
     def get_tacacs(self) -> TenantTacacsServer:

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -147,6 +147,7 @@ class TenantRadiusAPI:
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
+
 class TenantLevelRadiusAPI:
     """
     Class to configure tenant remote AAA RADIUS servers as tenant level users.
@@ -216,7 +217,7 @@ class TenantLevelRadiusAPI:
         logger.debug("Retrieving RADIUS server configuration.")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
-    
+ 
 
 class TenantTacacsAPI:
     """

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -101,7 +101,6 @@ class TenantRadiusAPI:
     def __init__(self, session: ManagerSession) -> None:
         self.session = session
         self.url_path = "/dataservice/admin/radius"
-        self.tenant_id = self.session.get_tenant_id()
 
     def __str__(self) -> str:
         return str(self.session)
@@ -113,7 +112,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug(f"Add RADIUS config tenant_id={self.tenant_id}.")
+        logger.debug("Add RADIUS config")
         data = asdict(radius_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -124,7 +123,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug(f"Update RADIUS config tenant_id={self.tenant_id}.")
+        logger.debug("Update RADIUS config")
         data = asdict(radius_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -135,7 +134,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return: True|False
         """
-        logger.debug(f"Delete RADIUS config tenant_id={self.tenant_id}.")
+        logger.debug("Delete RADIUS config")
         return self.session.delete(self.url_path)
 
     def get_radius(self) -> TenantRadiusServer:
@@ -143,78 +142,7 @@ class TenantRadiusAPI:
         Retrieve Radius server
         :return: TenantRadiusServer
         """
-        logger.debug(f"RADIUS config tenant_id={self.tenant_id}.")
-        data = self.session.get_data(self.url_path)
-        return create_dataclass(TenantRadiusServer, data)
-
-
-class TenantLevelRadiusAPI:
-    """
-    Class to configure tenant remote AAA RADIUS servers as tenant level users.
-    """
-
-    def __init__(self, session: ManagerSession) -> None:
-        self.session = session
-        self.url_path = "/dataservice/admin/radius"
-
-    def __str__(self) -> str:
-        return str(self.session)
-
-    @status_ok
-    def add_radius(self, radius_server: TenantRadiusServer):
-        """
-        Create RADIUS server for tenant.
-        :param radius_server: TenantRadiusServer object containing the server configuration.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Adding RADIUS server.")
-        data = asdict(radius_server)  # type: ignore
-        try:
-            response = self.session.post(url=self.url_path, json=data)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error adding RADIUS server: {e}")
-            return False
-
-    @status_ok
-    def put_radius(self, radius_server: TenantRadiusServer):
-        """
-        Edit RADIUS server for tenant.
-        :param radius_server: TenantRadiusServer object containing the server configuration.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Updating RADIUS server.")
-        data = asdict(radius_server)  # type: ignore
-        try:
-            response = self.session.put(url=self.url_path, json=data)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error updating RADIUS server: {e}")
-            return False
-
-    @status_ok
-    def delete_radius(self):
-        """
-        Delete RADIUS server for tenant.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Deleting RADIUS server.")
-        try:
-            response = self.session.delete(self.url_path)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error deleting RADIUS server: {e}")
-            return False
-
-    def get_radius(self) -> TenantRadiusServer:
-        """
-        Retrieve RADIUS server configuration for tenant.
-        :return: TenantRadiusServer object containing the server configuration.
-        """
-        logger.debug("Retrieving RADIUS server configuration.")
+        logger.debug("RADIUS config")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
@@ -227,7 +155,6 @@ class TenantTacacsAPI:
     def __init__(self, session: ManagerSession) -> None:
         self.session = session
         self.url_path = "/dataservice/admin/tacacs"
-        self.tenant_id = self.session.get_tenant_id()
 
     def __str__(self) -> str:
         return str(self.session)
@@ -239,7 +166,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug(f"TACACS config tenant_id={self.tenant_id}.")
+        logger.debug("TACACS config")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -250,7 +177,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug(f"Update TACACS config tenant_id={self.tenant_id}.")
+        logger.debug("Update TACACS config")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -261,7 +188,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return: True|False
         """
-        logger.debug(f"Delete TACACS config tenant_id={self.tenant_id}.")
+        logger.debug("Delete TACACS config")
         return self.session.delete(self.url_path)
 
     def get_tacacs(self) -> TenantTacacsServer:
@@ -269,77 +196,6 @@ class TenantTacacsAPI:
         Retrieves Tacacs server
         :return: TenantTacacsServer
         """
-        logger.debug(f"TACACS config tenant_id={self.tenant_id}.")
-        data = self.session.get_data(self.url_path)
-        return create_dataclass(TenantTacacsServer, data)
-
-
-class TenantLevelTacacsAPI:
-    """
-    Class to configure tenant remote AAA TACACS servers as tenant level user.
-    """
-
-    def __init__(self, session: ManagerSession) -> None:
-        self.session = session
-        self.url_path = "/dataservice/admin/tacacs"
-
-    def __str__(self) -> str:
-        return str(self.session)
-
-    @status_ok
-    def add_tacacs(self, tacacs_server: TenantTacacsServer):
-        """
-        Create TACACS server for tenant.
-        :param tacacs_server: TenantTacacsServer object containing the server configuration.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Adding TACACS server.")
-        data = asdict(tacacs_server)  # type: ignore
-        try:
-            response = self.session.post(url=self.url_path, json=data)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error adding TACACS server: {e}")
-            return False
-
-    @status_ok
-    def put_tacacs(self, tacacs_server: TenantTacacsServer):
-        """
-        Update TACACS server for tenant.
-        :param tacacs_server: TenantTacacsServer object containing the server configuration.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Updating TACACS server.")
-        data = asdict(tacacs_server)  # type: ignore
-        try:
-            response = self.session.put(url=self.url_path, json=data)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error updating TACACS server: {e}")
-            return False
-
-    @status_ok
-    def delete_tacacs(self):
-        """
-        Delete TACACS server for tenant.
-        :return: True if successful, False otherwise.
-        """
-        logger.debug("Deleting TACACS server.")
-        try:
-            response = self.session.delete(self.url_path)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Error deleting TACACS server: {e}")
-            return False
-
-    def get_tacacs(self) -> TenantTacacsServer:
-        """
-        Retrieve TACACS server configuration for tenant.
-        :return: TenantTacacsServer object containing the server configuration.
-        """
-        logger.debug("Retrieving TACACS server configuration.")
+        logger.debug("TACACS config")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantTacacsServer, data)

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -208,6 +208,6 @@ class TenantTacacsAPI:
         Retrieves Tacacs server
         :return: TenantTacacsServer
         """
-        logger.debug(f"TACACS config {self.tenant_org_name}")
+        logger.debug("TACACS config")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantTacacsServer, data)

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -42,6 +42,14 @@ class TenantAaaAPI:
     def aaa_exists(self) -> bool:
         return True if self.session.get_data(self.url_path) else False
 
+    @property
+    def tenant_org_name(self):
+        """
+        Get the tenant org name
+        :return:
+        """
+        return self.endpoints.configuration_settings.get_organizations().first().org
+
     @status_ok
     def add_aaa(self, tenant_aaa: TenantAAA):
         """ "
@@ -63,7 +71,7 @@ class TenantAaaAPI:
         :param aaa:
         :return:
         """
-        logger.debug("AAA config .")
+        logger.debug("AAA config {self.tenant_org_name}")
         tenant_aaa = self.session.get_data(self.url_path)
         # return tenant_aaa
         return create_dataclass(TenantAAA, tenant_aaa)
@@ -75,8 +83,8 @@ class TenantAaaAPI:
         :return:
         """
         if not self.aaa_exists():
-            raise AAAConfigNotPresent("No AAA config present for Tenant")
-        logger.debug("Delete AAA config on tenant.")
+            raise AAAConfigNotPresent("No AAA config present for Tenant {self.tenant_org_name}")
+        logger.debug("Delete AAA config on tenant {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     @status_ok
@@ -101,6 +109,14 @@ class TenantRadiusAPI:
     def __str__(self) -> str:
         return str(self.session)
 
+    @property
+    def tenant_org_name(self):
+        """
+        Get the tenant org name
+        :return:
+        """
+        return self.endpoints.configuration_settings.get_organizations().first().org
+
     @status_ok
     def add_radius(self, radius_server: TenantRadiusServer):
         """
@@ -108,7 +124,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug("Add RADIUS config")
+        logger.debug("Add RADIUS config {self.tenant_org_name}")
         data = asdict(radius_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -119,7 +135,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return:
         """
-        logger.debug("Update RADIUS config")
+        logger.debug("Update RADIUS config {self.tenant_org_name}")
         data = asdict(radius_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -130,7 +146,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return: True|False
         """
-        logger.debug("Delete RADIUS config")
+        logger.debug("Delete RADIUS config {self.tenant_org_name}") 
         return self.session.delete(self.url_path)
 
     def get_radius(self) -> TenantRadiusServer:
@@ -138,7 +154,7 @@ class TenantRadiusAPI:
         Retrieve Radius server
         :return: TenantRadiusServer
         """
-        logger.debug("RADIUS config")
+        logger.debug("RADIUS config {self.tenant_org_name}")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
@@ -155,6 +171,14 @@ class TenantTacacsAPI:
     def __str__(self) -> str:
         return str(self.session)
 
+    @property
+    def tenant_org_name(self):
+        """
+        Get the tenant org name
+        :return:
+        """
+        return self.endpoints.configuration_settings.get_organizations().first().org
+
     @status_ok
     def add_tacacs(self, tacacs_server: TenantTacacsServer):
         """
@@ -162,7 +186,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug("TACACS config")
+        logger.debug("TACACS config {self.tenant_org_name}")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.post(url=self.url_path, json=data)
 
@@ -173,7 +197,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return:
         """
-        logger.debug("Update TACACS config")
+        logger.debug("Update TACACS config {self.tenant_org_name}")
         data = asdict(tacacs_server)  # type: ignore
         return self.session.put(url=self.url_path, json=data)
 
@@ -184,7 +208,7 @@ class TenantTacacsAPI:
         :param tacacs_server:
         :return: True|False
         """
-        logger.debug("Delete TACACS config")
+        logger.debug("Delete TACACS config {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     def get_tacacs(self) -> TenantTacacsServer:
@@ -192,6 +216,6 @@ class TenantTacacsAPI:
         Retrieves Tacacs server
         :return: TenantTacacsServer
         """
-        logger.debug("TACACS config")
+        logger.debug("TACACS config {self.tenant_org_name}")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantTacacsServer, data)

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from catalystwan.dataclasses import TenantAAA, TenantRadiusServer, TenantTacacsServer
 from catalystwan.exceptions import CatalystwanException
 from catalystwan.utils.creation_tools import asdict, create_dataclass
+from catalystwan.models.tenant import TenantExport
 
 if TYPE_CHECKING:
     from catalystwan.session import ManagerSession

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -63,7 +63,7 @@ class TenantAaaAPI:
         :param aaa:
         :return:
         """
-        logger.debug(f"AAA config .")
+        logger.debug("AAA config .")
         tenant_aaa = self.session.get_data(self.url_path)
         # return tenant_aaa
         return create_dataclass(TenantAAA, tenant_aaa)
@@ -75,8 +75,8 @@ class TenantAaaAPI:
         :return:
         """
         if not self.aaa_exists():
-            raise AAAConfigNotPresent(f"No AAA config present for Tenant")
-        logger.debug(f"Delete AAA config on tenant.")
+            raise AAAConfigNotPresent("No AAA config present for Tenant")
+        logger.debug("Delete AAA config on tenant.")
         return self.session.delete(self.url_path)
 
     @status_ok

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -147,6 +147,76 @@ class TenantRadiusAPI:
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
 
+class TenantLevelRadiusAPI:
+    """
+    Class to configure tenant remote AAA RADIUS servers as tenant level users.
+    """
+
+    def __init__(self, session: ManagerSession) -> None:
+        self.session = session
+        self.url_path = "/dataservice/admin/radius"
+
+    def __str__(self) -> str:
+        return str(self.session)
+
+    @status_ok
+    def add_radius(self, radius_server: TenantRadiusServer):
+        """
+        Create RADIUS server for tenant.
+        :param radius_server: TenantRadiusServer object containing the server configuration.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Adding RADIUS server.")
+        data = asdict(radius_server)  # type: ignore
+        try:
+            response = self.session.post(url=self.url_path, json=data)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error adding RADIUS server: {e}")
+            return False
+
+    @status_ok
+    def put_radius(self, radius_server: TenantRadiusServer):
+        """
+        Edit RADIUS server for tenant.
+        :param radius_server: TenantRadiusServer object containing the server configuration.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Updating RADIUS server.")
+        data = asdict(radius_server)  # type: ignore
+        try:
+            response = self.session.put(url=self.url_path, json=data)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error updating RADIUS server: {e}")
+            return False
+
+    @status_ok
+    def delete_radius(self):
+        """
+        Delete RADIUS server for tenant.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Deleting RADIUS server.")
+        try:
+            response = self.session.delete(self.url_path)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting RADIUS server: {e}")
+            return False
+
+    def get_radius(self) -> TenantRadiusServer:
+        """
+        Retrieve RADIUS server configuration for tenant.
+        :return: TenantRadiusServer object containing the server configuration.
+        """
+        logger.debug("Retrieving RADIUS server configuration.")
+        data = self.session.get_data(self.url_path)
+        return create_dataclass(TenantRadiusServer, data)
+    
 
 class TenantTacacsAPI:
     """
@@ -199,5 +269,76 @@ class TenantTacacsAPI:
         :return: TenantTacacsServer
         """
         logger.debug(f"TACACS config tenant_id={self.tenant_id}.")
+        data = self.session.get_data(self.url_path)
+        return create_dataclass(TenantTacacsServer, data)
+
+
+class TenantLevelTacacsAPI:
+    """
+    Class to configure tenant remote AAA TACACS servers as tenant level user.
+    """
+
+    def __init__(self, session: ManagerSession) -> None:
+        self.session = session
+        self.url_path = "/dataservice/admin/tacacs"
+
+    def __str__(self) -> str:
+        return str(self.session)
+
+    @status_ok
+    def add_tacacs(self, tacacs_server: TenantTacacsServer):
+        """
+        Create TACACS server for tenant.
+        :param tacacs_server: TenantTacacsServer object containing the server configuration.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Adding TACACS server.")
+        data = asdict(tacacs_server)  # type: ignore
+        try:
+            response = self.session.post(url=self.url_path, json=data)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error adding TACACS server: {e}")
+            return False
+
+    @status_ok
+    def put_tacacs(self, tacacs_server: TenantTacacsServer):
+        """
+        Update TACACS server for tenant.
+        :param tacacs_server: TenantTacacsServer object containing the server configuration.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Updating TACACS server.")
+        data = asdict(tacacs_server)  # type: ignore
+        try:
+            response = self.session.put(url=self.url_path, json=data)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error updating TACACS server: {e}")
+            return False
+
+    @status_ok
+    def delete_tacacs(self):
+        """
+        Delete TACACS server for tenant.
+        :return: True if successful, False otherwise.
+        """
+        logger.debug("Deleting TACACS server.")
+        try:
+            response = self.session.delete(self.url_path)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting TACACS server: {e}")
+            return False
+
+    def get_tacacs(self) -> TenantTacacsServer:
+        """
+        Retrieve TACACS server configuration for tenant.
+        :return: TenantTacacsServer object containing the server configuration.
+        """
+        logger.debug("Retrieving TACACS server configuration.")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantTacacsServer, data)

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from catalystwan.dataclasses import TenantAAA, TenantRadiusServer, TenantTacacsServer
 from catalystwan.exceptions import CatalystwanException
 from catalystwan.utils.creation_tools import asdict, create_dataclass
-from catalystwan.models.tenant import TenantExport
 
 if TYPE_CHECKING:
     from catalystwan.session import ManagerSession
@@ -40,10 +39,6 @@ class TenantAaaAPI:
     def __str__(self) -> str:
         return str(self.session)
 
-    @property
-    def tenant_id(self):
-        return self.session.get_tenant_id()
-
     def aaa_exists(self) -> bool:
         return True if self.session.get_data(self.url_path) else False
 
@@ -68,7 +63,7 @@ class TenantAaaAPI:
         :param aaa:
         :return:
         """
-        logger.debug(f"AAA config {self.tenant_id}.")
+        logger.debug(f"AAA config .")
         tenant_aaa = self.session.get_data(self.url_path)
         # return tenant_aaa
         return create_dataclass(TenantAAA, tenant_aaa)
@@ -80,8 +75,8 @@ class TenantAaaAPI:
         :return:
         """
         if not self.aaa_exists():
-            raise AAAConfigNotPresent(f"No AAA config present for Tenant id={self.tenant_id}")
-        logger.debug(f"Delete AAA config on tenant_id={self.tenant_id}.")
+            raise AAAConfigNotPresent(f"No AAA config present for Tenant")
+        logger.debug(f"Delete AAA config on tenant.")
         return self.session.delete(self.url_path)
 
     @status_ok

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -146,7 +146,7 @@ class TenantRadiusAPI:
         :param radius_server:
         :return: True|False
         """
-        logger.debug("Delete RADIUS config {self.tenant_org_name}") 
+        logger.debug("Delete RADIUS config {self.tenant_org_name}")
         return self.session.delete(self.url_path)
 
     def get_radius(self) -> TenantRadiusServer:

--- a/catalystwan/api/mtt_aaa_api.py
+++ b/catalystwan/api/mtt_aaa_api.py
@@ -217,7 +217,7 @@ class TenantLevelRadiusAPI:
         logger.debug("Retrieving RADIUS server configuration.")
         data = self.session.get_data(self.url_path)
         return create_dataclass(TenantRadiusServer, data)
- 
+
 
 class TenantTacacsAPI:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalystwan"
-version = "0.36.0"
+version = "0.36.1"
 description = "Cisco Catalyst WAN SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
add support for tenant level user to make API calls for mtt aaa.
currently only provider as a tenant user is able to make API calls because there are provider level calls in the existing classes that are forbidden for tenant level users.

# Description of changes:
i have added 2 more classes, where we don't invoke provider level APIs.
So tenant level users can add tacacs or radius servers

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
